### PR TITLE
add auv_hardware and bridges

### DIFF
--- a/auv_hardware/auv_hardware/CMakeLists.txt
+++ b/auv_hardware/auv_hardware/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(auv_hardware)
+
+find_package(catkin REQUIRED COMPONENTS
+  auv_hardware_bridge
+)
+
+catkin_package()

--- a/auv_hardware/auv_hardware/package.xml
+++ b/auv_hardware/auv_hardware/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>auv_hardware</name>
+  <version>0.1.0</version>
+  <description>Metapackage for hardware interfacing</description>
+
+  <maintainer email="senceryazici@gmail.com">Sencer Yazici</maintainer>
+  <author email="senceryazici@gmail.com">Sencer Yazici</author>
+
+  <license>BSD-3-Clause</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <depend>auv_hardware_bridge</depend>
+
+  <export>
+
+  </export>
+</package>

--- a/auv_hardware/auv_hardware_bridge/CMakeLists.txt
+++ b/auv_hardware/auv_hardware_bridge/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(auv_hardware_bridge)
+
+find_package(catkin REQUIRED COMPONENTS
+  rosserial_python
+)
+
+catkin_package()
+
+include_directories(
+
+  # include
+  ${catkin_INCLUDE_DIRS}
+)
+
+install(DIRECTORY
+  launch
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)

--- a/auv_hardware/auv_hardware_bridge/launch/start_expansion_board_bridge.launch
+++ b/auv_hardware/auv_hardware_bridge/launch/start_expansion_board_bridge.launch
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="namespace" default="turquoise" />
+  <arg name="port" default="/dev/ttyACM0" />
+  <arg name="baudrate" default="1500000" />
+
+  <group ns="$(arg namespace)">
+    <node pkg="rosserial_python" type="serial_node.py" name="expansion_board_bridge_node"
+      args="$(arg port) _baud:=$(arg baudrate)" output="screen" respawn="true" />
+  </group>
+
+</launch>

--- a/auv_hardware/auv_hardware_bridge/package.xml
+++ b/auv_hardware/auv_hardware_bridge/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>auv_hardware_bridge</name>
+  <version>0.1.0</version>
+  <description>Contains bridge nodes for interfacing with hardware</description>
+
+  <author email="senceryazici@gmail.com">Sencer Yazici</author>
+  <maintainer email="senceryazici@gmail.com">Sencer Yazici</maintainer>
+
+  <license>BSD-3-Clause</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <depend>rosserial_python</depend>
+
+  <export>
+
+  </export>
+</package>


### PR DESCRIPTION
Add expansion board bridge & `auv_hardware` metapackage for hardware interfacing. Closes #13 