### PR TITLE
WIP: rearrange order

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -17,7 +17,6 @@ jobs:
       image_type: base
 
   native-ci:
-    needs: build-and-push-base-docker
     strategy:
       fail-fast: false
       matrix:
@@ -28,7 +27,7 @@ jobs:
       docker_image_tag: ghcr.io/itu-auv/auv-software-base:latest
   
   build-and-push-main-docker:
-    needs: native-ci
+    needs: [native-ci, build-and-push-base-docker]
     uses: ./.github/workflows/build_and_push_images.yml
     with:
       image_type: main


### PR DESCRIPTION
It looks like there is a meaningless dependency in CI execution. Allowing parallel run will make the whole batch complete faster.