### PR TITLE
Faruk/add config files

### DIFF
--- a/auv_sim/auv_sim_description/auv_common_sim_descriptions/urdf/actuators/model.config
+++ b/auv_sim/auv_sim_description/auv_common_sim_descriptions/urdf/actuators/model.config
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<model>
+  <name>actuators</name>
+  <version>1.0</version>
+  <sdf version="1.6">model.sdf</sdf>
+  <author>
+    <name>senceryazici</name>
+    <email>senceryazici@gmail.com</email>
+  </author>
+  <description>
+    Model configuration for actuators.
+  </description>
+</model>

--- a/auv_sim/auv_sim_description/auv_common_sim_descriptions/urdf/sensors/model.config
+++ b/auv_sim/auv_sim_description/auv_common_sim_descriptions/urdf/sensors/model.config
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<model>
+  <name>sensors</name>
+  <version>1.0</version>
+  <sdf version="1.6">model.sdf</sdf>
+  <author>
+    <name>senceryazici</name>
+    <email>senceryazici@gmail.com</email>
+  </author>
+  <description>
+    Model configuration for sensors.
+  </description>
+</model>


### PR DESCRIPTION
[Err] [InsertModelWidget.cc:403] Missing model.config for model "/home/frk/catkin_ws/src/auv-software/auv_sim/auv_sim_description/auv_common_sim_descriptions/urdf/actuators"

[Err] [InsertModelWidget.cc:403] Missing model.config for model "/home/frk/catkin_ws/src/auv-software/auv_sim/auv_sim_description/auv_common_sim_descriptions/urdf/sensors"

used to get this eror  messages  after launching the file start_gazebo.launch.

things ı have tried:
     Created a folder named config in the urdf directory and added the necessary files.
     Created a folder named configuration in the urdf directory and added the necessary files.
     Added the model.config files in every config directory related to auv_sim_description.

Only adding the file this way solved the issue:
added file to: /auv-software/auv_sim/auv_sim_description/auv_common_sim_descriptions/urdf/actuators/model.config
added file to: /auv-software/auv_sim/auv_sim_description/auv_common_sim_descriptions/urdf/sensors/model.config
