### PR TITLE
fix orientation control

### DIFF
--- a/auv_common_lib/src/ros/conversions.cpp
+++ b/auv_common_lib/src/ros/conversions.cpp
@@ -6,6 +6,8 @@
 #include "geometry_msgs/Pose.h"
 #include "geometry_msgs/Wrench.h"
 #include "nav_msgs/Odometry.h"
+#include "tf2/LinearMath/Matrix3x3.h"
+#include "tf2/LinearMath/Quaternion.h"
 
 namespace auv {
 namespace common {
@@ -32,9 +34,10 @@ geometry_msgs::Point convert(const Eigen::Vector3d& from) {
 
 template <>
 Eigen::Vector3d convert(const geometry_msgs::Quaternion& from) {
-  // quaternion to euler angles
-  Eigen::Quaterniond q(from.w, from.x, from.y, from.z);
-  return q.toRotationMatrix().eulerAngles(0, 1, 2);
+  const auto quaternion = tf2::Quaternion(from.x, from.y, from.z, from.w);
+  double roll, pitch, yaw;
+  tf2::Matrix3x3(quaternion).getRPY(roll, pitch, yaw);
+  return Eigen::Vector3d(roll, pitch, yaw);
 }
 
 template <>

--- a/auv_control/auv_controllers/CMakeLists.txt
+++ b/auv_control/auv_controllers/CMakeLists.txt
@@ -7,6 +7,8 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
   auv_common_lib
   pluginlib
+  angles
+  tf2
 )
 
 find_package(Eigen3 REQUIRED)
@@ -14,7 +16,7 @@ find_package(Eigen3 REQUIRED)
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES auv_controllers
-#  CATKIN_DEPENDS roscpp
+  CATKIN_DEPENDS roscpp auv_common_lib pluginlib angles tf2
 #  DEPENDS system_lib
 )
 

--- a/auv_control/auv_controllers/include/auv_controllers/multidof_pid_controller.h
+++ b/auv_control/auv_controllers/include/auv_controllers/multidof_pid_controller.h
@@ -4,6 +4,7 @@
 #include <array>
 #include <vector>
 
+#include "angles/angles.h"
 #include "auv_controllers/controller_base.h"
 
 namespace auv {
@@ -44,7 +45,13 @@ class MultiDOFPIDController : public ControllerBase<N> {
       const auto desired_position = desired_state.head(N);
       const auto velocity_state = d_state.head(N);
 
-      const auto error = desired_position - position_state;
+      Vectornd error = Vectornd::Zero();
+      error.head(3) = desired_position.head(3) - position_state.head(3);
+      for (size_t i = 3; i < N; ++i) {
+        error(i) = angles::shortest_angular_distance(position_state(i),
+                                                     desired_position(i));
+      }
+
       const auto p_term = kp_.template block<N, N>(0, 0) * error;
 
       integral_.head(N) += error * dt;

--- a/auv_control/auv_controllers/package.xml
+++ b/auv_control/auv_controllers/package.xml
@@ -11,6 +11,9 @@
   <build_export_depend>roscpp</build_export_depend>
   <exec_depend>roscpp</exec_depend>
   <depend>auv_common_lib</depend>
+  <depend>pluginlib</depend>
+  <depend>angles</depend>
+  <depend>tf2</depend>
   <export>
     <auv_controllers plugin="${prefix}/controller_plugins.xml"/>
   </export>


### PR DESCRIPTION
Quaternion to Euler angle conversion function was not working properly. There was an issue about wrapping/normalizing angles, and it was returning incorrect values, which caused problems while calculating the errors for pid.

<details><summary></code>Here is a log of what we calculate as orientation error while the robot is stable and `desired orientation = current orientation</code></summary>
<p><pre>[ WARN] [1734376964.945058667, 79.440000000]: ERRORS: -3.13868  3.13726 -3.14159
[ WARN] [1734376965.017779235, 79.490000000]: ERRORS: -3.13943  3.13808 -3.14098
[ WARN] [1734376965.098415150, 79.540000000]: ERRORS: -0.00404835  0.00684969 -0.00184575
[ WARN] [1734376965.175873698, 79.591000000]: ERRORS: -0.00404835  0.00684969  1.9409e-06
[ WARN] [1734376965.245359836, 79.640000000]: ERRORS: -0.00255844 2.78368e-05   0.0032894
[ WARN] [1734376965.334101698, 79.691000000]: ERRORS:  -0.00255844  2.78368e-05 -7.28495e-07
[ WARN] [1734376965.412282038, 79.742000000]: ERRORS: -3.13879  -3.1412   3.1394
[ WARN] [1734376965.478943995, 79.790000000]: ERRORS: -3.13879  -3.1412  3.14159
[ WARN] [1734376965.549079151, 79.840000000]: ERRORS: -3.14129  3.13889 -3.14159
[ WARN] [1734376965.621986137, 79.890000000]: ERRORS: -3.14015  3.13775 -3.14159
[ WARN] [1734376965.691235946, 79.940000000]: ERRORS: -3.13993 -3.13842 -3.14159
[ WARN] [1734376965.762883946, 79.990000000]: ERRORS: -0.000475707  -0.00142249  2.37797e-07
[ WARN] [1734376965.829678191, 80.040000000]: ERRORS:  -0.00194066  -0.00124898 -1.18903e-07
[ WARN] [1734376965.901844773, 80.090000000]: ERRORS: -3.13928  3.13964 -3.14159
[ WARN] [1734376965.977797889, 80.140000000]: ERRORS: -0.00129048  0.00177276 4.60844e-08
[ WARN] [1734376966.054011594, 80.190000000]: ERRORS: -3.14046 -3.13916 -3.14159
[ WARN] [1734376966.130143541, 80.240000000]: ERRORS: -3.14149  -3.1369 -3.14159
[ WARN] [1734376966.201170585, 80.290000000]: ERRORS:  -3.1375 -3.14064  3.14159
[ WARN] [1734376966.270812369, 80.340000000]: ERRORS: -3.13978  3.14124  3.14159
</pre></p></details>

As you can see there are momentary spikes in different directions.

Using the `getRPY` from `tf2` fixed this problem. 

<details><summary></code>Here is a log with the new conversion for the same robot in the same situation as above</code></summary>
<p><pre>[ WARN] [1734377173.795787442, 80.502000000]: ERRORS:  0.00307924 0.000497908           0
[ WARN] [1734377173.866134977, 80.552000000]: ERRORS:   0.0026372 -0.00181464           0
[ WARN] [1734377173.937761568, 80.602000000]: ERRORS: -0.000612973   0.00333478            0
[ WARN] [1734377174.006744663, 80.652000000]: ERRORS: -0.000696007  0.000332932            0
[ WARN] [1734377174.081988113, 80.702000000]: ERRORS:  0.00317154 -0.00268578           0
[ WARN] [1734377174.155461854, 80.752000000]: ERRORS: -0.00520951 0.000973729           0
[ WARN] [1734377174.223457961, 80.802000000]: ERRORS: -0.00239365  0.00153816           0
[ WARN] [1734377174.298094675, 80.852000000]: ERRORS: -0.00189129 -0.00285157           0
[ WARN] [1734377174.373855593, 80.902000000]: ERRORS: -0.00177189  0.00129925           0
[ WARN] [1734377174.446841712, 80.952000000]: ERRORS: 0.00339065 -0.0011142          0
[ WARN] [1734377174.523307864, 81.002000000]: ERRORS: -0.00637848  0.00575009           0
[ WARN] [1734377174.593969208, 81.052000000]: ERRORS: 0.00163956 0.00260196          0
[ WARN] [1734377174.667585740, 81.102000000]: ERRORS:  0.00105911 -0.00068892           0
[ WARN] [1734377174.744739643, 81.152000000]: ERRORS:   -0.0021691 -0.000981395            0
[ WARN] [1734377174.820596739, 81.202000000]: ERRORS: -0.000386076  -0.00294732  8.88178e-16
[ WARN] [1734377174.897713883, 81.252000000]: ERRORS: 0.000896389 0.000140089           0
[ WARN] [1734377174.974875797, 81.302000000]: ERRORS: 0.00539348 0.00549054          0
[ WARN] [1734377175.058197842, 81.352000000]: ERRORS:   0.00253818 -0.000558881            0
[ WARN] [1734377175.138078364, 81.402000000]: ERRORS: 0.00151056 0.00205325          0
[ WARN] [1734377175.207097833, 81.452000000]: ERRORS: -0.00136745 0.000109158           0
[ WARN] [1734377175.282713427, 81.502000000]: ERRORS: -0.00342338 -0.00290449           0</pre></p></details>

Other problem was about calculating the error for the euler angles. Simply extracting the values wasn't the correct way. Now we calculate the shorter angular distance using a function from `angles` package.