### PR TITLE
WIP: smach shutdown handler

### DIFF
--- a/auv_control/auv_control/scripts/prop_transform_publisher.py
+++ b/auv_control/auv_control/scripts/prop_transform_publisher.py
@@ -22,6 +22,7 @@ import tf2_geometry_msgs
 import time
 import copy
 import threading
+from std_srvs.srv import Trigger, TriggerRequest, TriggerResponse
 
 
 class Scene:
@@ -310,6 +311,10 @@ class ObjectPositionEstimator:
             "/taluy/map/set_object_transform", SetObjectTransform
         )
         self.set_object_transform_service.wait_for_service()
+
+        self.clear_transforms_service = rospy.Service(
+            "/taluy/clear_prop_transforms", Trigger, self.handle_clear_transforms
+        )
 
         # Subscriptions
         yolo_result_subscriber = message_filters.Subscriber("/yolo_result", YoloResult)
@@ -798,6 +803,10 @@ class ObjectPositionEstimator:
         # transform_message.transform.rotation.y = 0.0
         # transform_message.transform.rotation.z = 0.0
         # transform_message.transform.rotation.w = 1.0
+
+    def handle_clear_transforms(self, req: TriggerRequest):
+        self.scene = Scene()
+        return TriggerResponse(success=True, message="Prop transforms cleared")
 
     def run(self):
         self.rate = rospy.Rate(30.0)

--- a/auv_navigation/auv_mapping/launch/start.launch
+++ b/auv_navigation/auv_mapping/launch/start.launch
@@ -9,6 +9,7 @@
       <param name="static_frame" value="odom" />
 
       <remap from="set_object_transform" to="map/set_object_transform" />
+      <remap from="clear_object_transforms" to="map/clear_object_transforms" />
     </node>
   </group>
 

--- a/auv_smach/scripts/main_state_machine.py
+++ b/auv_smach/scripts/main_state_machine.py
@@ -3,7 +3,6 @@
 import rospy
 import smach
 import auv_smach
-from auv_smach.common import CancelAlignControllerState
 from auv_smach.initialize import InitializeState
 from auv_smach.gate import NavigateThroughGateState
 from auv_smach.red_buoy import RotateAroundBuoyState

--- a/auv_smach/scripts/main_state_machine.py
+++ b/auv_smach/scripts/main_state_machine.py
@@ -4,7 +4,6 @@ import rospy
 import smach
 import auv_smach
 from auv_smach.common import CancelAlignControllerState
-from std_srvs.srv import Trigger, TriggerRequest
 from auv_smach.initialize import InitializeState
 from auv_smach.gate import NavigateThroughGateState
 from auv_smach.red_buoy import RotateAroundBuoyState

--- a/auv_smach/scripts/main_state_machine.py
+++ b/auv_smach/scripts/main_state_machine.py
@@ -10,6 +10,7 @@ from auv_smach.red_buoy import RotateAroundBuoyState
 from auv_smach.torpedo import TorpedoTaskState
 from auv_smach.bin import BinTaskState
 from auv_smach.octagon import OctagonTaskState
+from auv_smach.deinitialize import DeinitializeState
 from std_msgs.msg import Bool
 import threading
 
@@ -52,8 +53,8 @@ class MainStateMachineNode:
                 InitializeState(),
                 transitions={
                     "succeeded": "NAVIGATE_THROUGH_GATE",
-                    "preempted": "preempted",
-                    "aborted": "CANCEL_ALIGN_CONTROLLER",
+                    "preempted": "DEINITIALIZE",
+                    "aborted": "DEINITIALIZE",
                 },
             )
             smach.StateMachine.add(
@@ -61,8 +62,8 @@ class MainStateMachineNode:
                 NavigateThroughGateState(gate_depth=gate_depth),
                 transitions={
                     "succeeded": "NAVIGATE_AROUND_RED_BUOY",
-                    "preempted": "preempted",
-                    "aborted": "CANCEL_ALIGN_CONTROLLER",
+                    "preempted": "DEINITIALIZE",
+                    "aborted": "DEINITIALIZE",
                 },
             )
             smach.StateMachine.add(
@@ -74,8 +75,8 @@ class MainStateMachineNode:
                 ),
                 transitions={
                     "succeeded": "NAVIGATE_TO_TORPEDO_TASK",
-                    "preempted": "preempted",
-                    "aborted": "CANCEL_ALIGN_CONTROLLER",
+                    "preempted": "DEINITIALIZE",
+                    "aborted": "DEINITIALIZE",
                 },
             )
             smach.StateMachine.add(
@@ -86,8 +87,8 @@ class MainStateMachineNode:
                 ),
                 transitions={
                     "succeeded": "NAVIGATE_TO_BIN_TASK",
-                    "preempted": "preempted",
-                    "aborted": "CANCEL_ALIGN_CONTROLLER",
+                    "preempted": "DEINITIALIZE",
+                    "aborted": "DEINITIALIZE",
                 },
             )
             smach.StateMachine.add(
@@ -97,8 +98,8 @@ class MainStateMachineNode:
                 ),
                 transitions={
                     "succeeded": "NAVIGATE_TO_OCTAGON_TASK",
-                    "preempted": "preempted",
-                    "aborted": "CANCEL_ALIGN_CONTROLLER",
+                    "preempted": "DEINITIALIZE",
+                    "aborted": "DEINITIALIZE",
                 },
             )
             smach.StateMachine.add(
@@ -108,13 +109,13 @@ class MainStateMachineNode:
                 ),
                 transitions={
                     "succeeded": "succeeded",
-                    "preempted": "preempted",
-                    "aborted": "CANCEL_ALIGN_CONTROLLER",
+                    "preempted": "DEINITIALIZE",
+                    "aborted": "DEINITIALIZE",
                 },
             )
             smach.StateMachine.add(
-                "CANCEL_ALIGN_CONTROLLER",
-                CancelAlignControllerState(),
+                "DEINITIALIZE",
+                DeinitializeState(),
                 transitions={
                     "succeeded": "aborted",
                     "preempted": "preempted",

--- a/auv_smach/src/auv_smach/common.py
+++ b/auv_smach/src/auv_smach/common.py
@@ -250,3 +250,13 @@ class NavigateToFrameState(smach.State):
         ) as e:
             rospy.logwarn(f"TF lookup exception: {e}")
             return "aborted"
+
+
+class ClearObjectTransformsState(smach_ros.ServiceState):
+    def __init__(self):
+        smach_ros.ServiceState.__init__(
+            self,
+            "/taluy/map/clear_object_transforms",
+            Trigger,
+            request=TriggerRequest(),
+        )

--- a/auv_smach/src/auv_smach/common.py
+++ b/auv_smach/src/auv_smach/common.py
@@ -260,3 +260,13 @@ class ClearObjectTransformsState(smach_ros.ServiceState):
             Trigger,
             request=TriggerRequest(),
         )
+
+
+class ClearPropTransformsState(smach_ros.ServiceState):
+    def __init__(self):
+        smach_ros.ServiceState.__init__(
+            self,
+            "/taluy/clear_prop_transforms",
+            Trigger,
+            request=TriggerRequest(),
+        )

--- a/auv_smach/src/auv_smach/deinitialize.py
+++ b/auv_smach/src/auv_smach/deinitialize.py
@@ -1,6 +1,10 @@
 import smach
 
-from auv_smach.common import CancelAlignControllerState, ClearObjectTransformsState
+from auv_smach.common import (
+    CancelAlignControllerState,
+    ClearObjectTransformsState,
+    ClearPropTransformsState,
+)
 
 
 class DeinitializeState(smach.State):
@@ -26,6 +30,15 @@ class DeinitializeState(smach.State):
             smach.StateMachine.add(
                 "CLEAR_OBJECT_TRANSFORMS",
                 ClearObjectTransformsState(),
+                transitions={
+                    "succeeded": "CLEAR_PROP_TRANSFORMS",
+                    "preempted": "CLEAR_PROP_TRANSFORMS",
+                    "aborted": "CLEAR_PROP_TRANSFORMS",
+                },
+            )
+            smach.StateMachine.add(
+                "CLEAR_PROP_TRANSFORMS",
+                ClearPropTransformsState(),
                 transitions={
                     "succeeded": "aborted",
                     "preempted": "preempted",

--- a/auv_smach/src/auv_smach/deinitialize.py
+++ b/auv_smach/src/auv_smach/deinitialize.py
@@ -1,0 +1,48 @@
+import smach
+import rospy
+import tf2_ros
+
+from std_msgs.msg import Bool
+
+from auv_smach.common import CancelAlignControllerState, ClearObjectTransformsState
+
+
+class DeinitializeState(smach.State):
+    def __init__(self):
+        smach.State.__init__(self, outcomes=["succeeded", "preempted", "aborted"])
+
+        # Initialize the state machine
+        self.state_machine = smach.StateMachine(
+            outcomes=["succeeded", "preempted", "aborted"]
+        )
+
+        # Open the container for adding states
+        with self.state_machine:
+            smach.StateMachine.add(
+                "CANCEL_ALIGN_CONTROLLER",
+                CancelAlignControllerState(),
+                transitions={
+                    "succeeded": "CLEAR_OBJECT_TRANSFORMS",
+                    "preempted": "CLEAR_OBJECT_TRANSFORMS",
+                    "aborted": "CLEAR_OBJECT_TRANSFORMS",
+                },
+            )
+            smach.StateMachine.add(
+                "CLEAR_OBJECT_TRANSFORMS",
+                ClearObjectTransformsState(),
+                transitions={
+                    "succeeded": "aborted",
+                    "preempted": "preempted",
+                    "aborted": "aborted",
+                },
+            )
+
+    def execute(self, userdata):
+        # Execute the state machine
+        outcome = self.state_machine.execute()
+
+        if outcome is None:
+            return "preempted"
+
+        # Return the outcome of the state machine
+        return outcome

--- a/auv_smach/src/auv_smach/deinitialize.py
+++ b/auv_smach/src/auv_smach/deinitialize.py
@@ -1,8 +1,4 @@
 import smach
-import rospy
-import tf2_ros
-
-from std_msgs.msg import Bool
 
 from auv_smach.common import CancelAlignControllerState, ClearObjectTransformsState
 


### PR DESCRIPTION
Closes #104 

Sometimes we need to shutdown the smach to prevent the robot from getting damaged. This results in robot trying to align itself to the latest frame we have sent to `align_frame_controller`.

With this change we call the `taluy/control/align_frame/cancel` service when the smach is killed, which cancels the `align_frame_controller`, so the robot stays stable.