### PR TITLE
remove legacy barrel roll state

### DIFF
--- a/auv_smach/src/auv_smach/gate.py
+++ b/auv_smach/src/auv_smach/gate.py
@@ -69,15 +69,6 @@ class NavigateThroughGateState(smach.State):
                     "taluy/base_link", "gate_enterance", "gate_target"
                 ),
                 transitions={
-                    "succeeded": "BARREL_ROLL",
-                    "preempted": "preempted",
-                    "aborted": "aborted",
-                },
-            )
-            smach.StateMachine.add(
-                "BARREL_ROLL",
-                DoBarrelRoll(),
-                transitions={
                     "succeeded": "NAVIGATE_TO_GATE_EXIT",
                     "preempted": "preempted",
                     "aborted": "aborted",


### PR DESCRIPTION
Closes #80 

There is a `BARREL_ROLL` state in our smach that uses a legacy `DoBarrelRoll` function that no longer exists in our codebase. We can add this state in future again when we implement a new `DoBarrelRoll` function. 