### PR TITLE
temporarily remove dependencies requiring opencv dependencies

### DIFF
--- a/auv_vision/auv_detection/package.xml
+++ b/auv_vision/auv_detection/package.xml
@@ -7,8 +7,8 @@
   <maintainer email="t.ozanhakan@gmail.com">Ozan Hakan Tunca</maintainer>
   <license>BSD-3-Clause</license>
   <buildtool_depend>catkin</buildtool_depend>
-  <depend>ultralytics_ros</depend>
-  <depend>image_view</depend>
+  <!--<depend>ultralytics_ros</depend>-->
+  <!--<depend>image_view</depend>-->
   <export>
   </export>
 </package>


### PR DESCRIPTION
The jetson uses it's own distributed opencv libraries therefore `libopencv-dev` must not be installed. Recently introduced changes enforce rosdep to install opencv libraries even though `--skip-keys` are provided. Removing the dependency for now. This will be later addressed.