### PR TITLE
set default ultralytics device to 'cuda:0'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@
 
 *__pycache__*
 *.pyc
+
+# ultralytics models
+*.pt

--- a/auv_vision/auv_detection/launch/tracker.launch
+++ b/auv_vision/auv_detection/launch/tracker.launch
@@ -12,7 +12,7 @@
   <arg name="max_det" default="300"/>
   <arg name="classes" default=""/>
   <arg name="tracker" default="bytetrack.yaml"/>
-  <arg name="device" default="cpu"/>
+  <arg name="device" default="cuda:0"/>
   <arg name="result_conf" default="true"/>
   <arg name="result_line_width" default="1"/>
   <arg name="result_font_size" default="1"/>


### PR DESCRIPTION
This fixes an error from #97 by setting default ultralytics device to `cuda:0` for jetson instead of cpu.

There is also a small addition to `.gitignore` for model files, i thought it was okay to put it in this pr since it's somewhat related.