### PR TITLE
add option to run gazebo headless with use_gui

### DIFF
--- a/auv_sim/auv_sim_bringup/launch/inc/start_pool_world.launch
+++ b/auv_sim/auv_sim_bringup/launch/inc/start_pool_world.launch
@@ -6,13 +6,13 @@
     />
     <arg name="debug" default="false" />
     <arg name="namespace" default="taluy" />
-    <arg name="gui" default="true" />
+    <arg name="use_gui" default="true" />
     <arg name="world_name" value="$(find auv_sim_description)/worlds/pool.world" />
 
     <include file="$(find gazebo_ros)/launch/empty_world.launch">
         <arg name="world_name" value="$(arg world_name)" />
         <arg name="use_sim_time" value="true" />
-        <arg name="gui" value="$(arg gui)" />
+        <arg name="gui" value="$(arg use_gui)" />
         <arg name="headless" value="false" />
         <arg name="debug" value="$(arg debug)" />
         <arg name="verbose" value="true" />

--- a/auv_sim/auv_sim_bringup/launch/inc/start_seabed_world.launch
+++ b/auv_sim/auv_sim_bringup/launch/inc/start_seabed_world.launch
@@ -2,13 +2,13 @@
 <launch>
     <arg name="debug" default="false" />
     <arg name="namespace" default="taluy" />
-    <arg name="gui" default="true" />
+    <arg name="use_gui" default="true" />
     <arg name="world_name" value="$(find auv_sim_description)/worlds/seabed.world" />
 
     <include file="$(find gazebo_ros)/launch/empty_world.launch">
         <arg name="world_name" value="$(arg world_name)" />
         <arg name="use_sim_time" value="true" />
-        <arg name="gui" value="$(arg gui)" />
+        <arg name="gui" value="$(arg use_gui)" />
         <arg name="headless" value="false" />
         <arg name="debug" value="$(arg debug)" />
         <arg name="verbose" value="true" />

--- a/auv_sim/auv_sim_bringup/launch/start_gazebo.launch
+++ b/auv_sim/auv_sim_bringup/launch/start_gazebo.launch
@@ -35,7 +35,7 @@
 
     <!-- Start world launch -->
     <include file="$(find auv_sim_bringup)/launch/inc/start_$(arg world)_world.launch">
-        <arg name="gui" value="$(arg use_gui)" />
+        <arg name="use_gui" value="$(arg use_gui)" />
         <arg name="debug" value="$(arg debug)" />
         <arg name="namespace" value="$(arg namespace)" />
     </include>


### PR DESCRIPTION
We don't always need to see the gui to test the robot in simulation. We may also use this functionality in the future to test the robot performance in Github Actions CI.