### PR TITLE
WIP: Ozan/better logging

### DIFF
--- a/auv_bringup/launch/start.launch
+++ b/auv_bringup/launch/start.launch
@@ -5,7 +5,7 @@
   <arg name="dvl_virtual_port" default="/tmp/vcom0" />
   <arg name="use_gui" default="false" />
   <arg name="logging_directory" default="$(optenv HOME)/bags" />
-
+  <arg name="enable_logging" default="true" />
   <rosparam file="$(find auv_bringup)/config/environment.yaml" command="load" ns="" />
 
   <!-- launch state publisher  -->
@@ -47,26 +47,17 @@
     <arg name="namespace" value="$(arg namespace)" />
   </include>
 
-  <include file="$(find auv_localization)/launch/start.launch">
-    <arg name="namespace" value="$(arg namespace)" />
-  </include>
-
-  <include file="$(find auv_bringup)/launch/robot_localization.launch">
-    <arg name="namespace" value="$(arg namespace)" />
-  </include>
-
-  <include file="$(find auv_control)/launch/start.launch">
-    <arg name="namespace" value="$(arg namespace)" />
-  </include>
-
-  <include file="$(find auv_bringup)/launch/inc/logging.launch.xml">
-    <arg name="namespace" value="$(arg namespace)" />
-    <arg name="logging_directory" value="$(arg logging_directory)" />
-  </include>
-
-  <include file="$(find auv_mapping)/launch/start.launch">
+  <include file="$(find auv_bringup)/launch/start_navigation.launch">
     <arg name="namespace" value="$(arg namespace)" />
     <arg name="control_rate" value="$(arg control_rate)" />
+    <arg name="use_gui" value="$(arg use_gui)" />
+    <arg name="start_state_publisher" value="false" />
   </include>
 
+  <group if="$(arg enable_logging)">
+      <include file="$(find auv_bringup)/launch/inc/logging.launch.xml">
+          <arg name="namespace" value="$(arg namespace)" />
+          <arg name="logging_directory" value="$(arg logging_directory)" />
+      </include>
+  </group>
 </launch>

--- a/auv_bringup/launch/start.launch
+++ b/auv_bringup/launch/start.launch
@@ -6,6 +6,7 @@
   <arg name="use_gui" default="false" />
   <arg name="logging_directory" default="$(optenv HOME)/bags" />
   <arg name="enable_logging" default="true" />
+
   <rosparam file="$(find auv_bringup)/config/environment.yaml" command="load" ns="" />
 
   <!-- launch state publisher  -->
@@ -47,17 +48,28 @@
     <arg name="namespace" value="$(arg namespace)" />
   </include>
 
-  <include file="$(find auv_bringup)/launch/start_navigation.launch">
+  <include file="$(find auv_localization)/launch/start.launch">
     <arg name="namespace" value="$(arg namespace)" />
-    <arg name="control_rate" value="$(arg control_rate)" />
-    <arg name="use_gui" value="$(arg use_gui)" />
-    <arg name="start_state_publisher" value="false" />
+  </include>
+
+  <include file="$(find auv_bringup)/launch/robot_localization.launch">
+    <arg name="namespace" value="$(arg namespace)" />
+  </include>
+
+  <include file="$(find auv_control)/launch/start.launch">
+    <arg name="namespace" value="$(arg namespace)" />
   </include>
 
   <group if="$(arg enable_logging)">
-      <include file="$(find auv_bringup)/launch/inc/logging.launch.xml">
-          <arg name="namespace" value="$(arg namespace)" />
-          <arg name="logging_directory" value="$(arg logging_directory)" />
-      </include>
+        <include file="$(find auv_bringup)/launch/inc/logging.launch.xml">
+            <arg name="namespace" value="$(arg namespace)" />
+            <arg name="logging_directory" value="$(arg logging_directory)" />
+        </include>
   </group>
+
+  <include file="$(find auv_mapping)/launch/start.launch">
+    <arg name="namespace" value="$(arg namespace)" />
+    <arg name="control_rate" value="$(arg control_rate)" />
+  </include>
+
 </launch>

--- a/auv_sim/auv_sim_bringup/launch/start_gazebo.launch
+++ b/auv_sim/auv_sim_bringup/launch/start_gazebo.launch
@@ -1,0 +1,73 @@
+<?xml version="1.0"?>
+<launch>
+    <env
+        name="GAZEBO_MODEL_PATH"
+        value="$(find auv_sim_description)/models:${GAZEBO_MODEL_PATH}"
+    />
+    <arg name="namespace" default="taluy" />
+    <arg name="control_rate" default="20.0" />
+    <arg name="reference_frame" value="world" />
+    <arg name="use_gui" default="true" />
+    <arg name="debug" default="false" />
+    <arg name="world" default="pool" />
+    <arg name="use_ned_frame" default="false" />
+    <arg name="enable_logging" default="false" />
+    <arg name="logging_directory" default="$(optenv HOME)/bags" />  
+
+    <!-- Run RViz -->
+    <node
+        name="rviz"
+        pkg="rviz"
+        type="rviz"
+        args="-d $(find taluy_description)/rviz/yolo_cam.rviz"
+        if="$(arg use_gui)"
+    />
+
+    <!-- Initial robot position and orientation -->
+    <arg name="x" default="0.0" />
+    <arg name="y" default="0.0" />
+    <arg name="z" default="-1.5" if="$(eval arg('world') == 'pool')" />
+    <arg name="z" default="-87.0" if="$(eval arg('world') == 'seabed')" />
+    <arg name="roll" value="0" />
+    <arg name="pitch" value="0" />
+    <arg name="yaw" value="-1.8" />
+
+    <!-- Start world launch -->
+    <include file="$(find auv_sim_bringup)/launch/inc/start_$(arg world)_world.launch">
+        <arg name="gui" value="$(arg use_gui)" />
+        <arg name="debug" value="$(arg debug)" />
+        <arg name="namespace" value="$(arg namespace)" />
+    </include>
+
+    <!-- Spawn robot -->
+    <include file="$(find auv_sim_bringup)/launch/inc/spawn_robot.launch">
+        <arg name="debug" value="$(arg debug)" />
+        <arg name="namespace" value="$(arg namespace)" />
+        <arg name="control_rate" value="$(arg control_rate)" />
+        <arg name="use_ned_frame" value="$(arg use_ned_frame)" />
+        <arg name="reference_frame" value="$(arg reference_frame)" />
+        <arg name="x" value="$(arg x)" />
+        <arg name="y" value="$(arg y)" />
+        <arg name="z" value="$(arg z)" />
+        <arg name="roll" value="$(arg roll)" />
+        <arg name="pitch" value="$(arg pitch)" />
+        <arg name="yaw" value="$(arg yaw)" />
+    </include>
+
+    <!-- Start bridge -->
+    <include file="$(find auv_sim_bringup)/launch/inc/start_bridge.launch">
+        <arg name="namespace" value="$(arg namespace)" />
+        <arg name="control_rate" value="$(arg control_rate)" />
+        <arg name="use_gui" value="$(arg use_gui)" />
+    </include>
+
+    <group if="$(arg enable_logging)">
+        <include file="$(find auv_bringup)/launch/inc/logging.launch.xml">
+            <arg name="namespace" value="$(arg namespace)" />
+            <arg name="logging_directory" value="$(arg logging_directory)" />
+        </include>
+    </group>
+
+<!-- TODO (eminmeydanoglu): add start camera process here -->
+
+</launch>


### PR DESCRIPTION
1. Option to disable logging
We sometimes (actually in most of the times we launch start.launch) don't want the logging to start. Continuous logging during each launch can clutter the bag files, making it harder to search through them later and eating up storage space. To address this, I introduce a boolean flag to disable logging when not needed.
2. Logging functionality in simulation
Ability to log in simulation is super helpful for debugging! One can't keep track of all events and numbers whilst the simulation is running. Bug files enable a rigorous analysis of events that occurred during the runtime