### PR TITLE
Add support for WrenchStamped

### DIFF
--- a/auv_control/auv_control/include/auv_control/controller_ros.h
+++ b/auv_control/auv_control/include/auv_control/controller_ros.h
@@ -16,6 +16,9 @@
 #include "pluginlib/class_loader.h"
 #include "ros/ros.h"
 #include "std_msgs/Bool.h"
+#include "tf2_ros/buffer.h"
+#include "tf2_ros/transform_listener.h"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.h"
 
 namespace auv {
 namespace control {
@@ -36,7 +39,8 @@ class ControllerROS {
       auv::common::ros::SubscriberWithTimeout<std_msgs::Bool>;
 
   ControllerROS(const ros::NodeHandle& nh)
-      : nh_{nh}, rate_{1.0}, control_enable_sub_{nh} {
+      : nh_{nh}, rate_{1.0}, control_enable_sub_{nh},
+        tf_buffer_{}, tf_listener_{tf_buffer_} {
     ros::NodeHandle nh_private("~");
 
     auto model = ModelParser::parse("model", nh_private);
@@ -46,6 +50,9 @@ class ControllerROS {
 
     const auto rate = nh_private.param("rate", 10.0);
     rate_ = ros::Rate{rate};
+
+    nh_private.param<std::string>("body_frame", body_frame_, "taluy/base_link");
+    nh_private.param<double>("transform_timeout", transform_timeout_, 1.0);
 
     ROS_INFO_STREAM("kp: \n" << kp_.transpose());
     ROS_INFO_STREAM("ki: \n" << ki_.transpose());
@@ -89,7 +96,7 @@ class ControllerROS {
         ros::Duration{1.0});
     control_enable_sub_.set_default_message(std_msgs::Bool{});
 
-    wrench_pub_ = nh_.advertise<geometry_msgs::Wrench>("wrench", 1);
+    wrench_pub_ = nh_.advertise<geometry_msgs::WrenchStamped>("wrench", 1);
   }
 
   bool load_controller(const std::string& controller_name) {
@@ -119,19 +126,22 @@ class ControllerROS {
       const auto control_output =
           controller_->control(state_, desired_state_, d_state_, dt);
 
-      const auto wrench_msg =
-          (is_control_enabled() && !is_timeouted())
-              ? auv::common::conversions::convert<ControllerBase::WrenchVector,
-                                                  geometry_msgs::Wrench>(
-                    control_output)
-              : geometry_msgs::Wrench{};
-
-      wrench_pub_.publish(wrench_msg);
+      geometry_msgs::WrenchStamped wrench_msg;
+        if (is_control_enabled() && !is_timeouted()) {
+          wrench_msg.header.stamp = ros::Time::now();
+          wrench_msg.header.frame_id = body_frame_;
+          wrench_msg.wrench = auv::common::conversions::convert<ControllerBase::WrenchVector,geometry_msgs::Wrench>(control_output);
+          wrench_pub_.publish(wrench_msg);
+        }
     }
   }
 
- private:
-  bool is_control_enabled() { return control_enable_sub_.get_message().data; }
+  private:
+   bool is_control_enabled() { return control_enable_sub_.get_message().data; }
+   tf2_ros::Buffer tf_buffer_;
+   tf2_ros::TransformListener tf_listener_;
+   std::string body_frame_;
+   double transform_timeout_;
 
   bool is_timeouted() const {
     return (ros::Time::now() - latest_command_time_).toSec() > 1.0;

--- a/auv_control/auv_control/include/auv_control/thruster_manager_ros.h
+++ b/auv_control/auv_control/include/auv_control/thruster_manager_ros.h
@@ -7,6 +7,9 @@
 #include "auv_msgs/MotorCommand.h"
 #include "auv_msgs/Power.h"
 #include "ros/ros.h"
+#include "tf2_ros/buffer.h"
+#include "tf2_ros/transform_listener.h"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.h"
 
 namespace auv {
 namespace control {
@@ -19,7 +22,8 @@ class ThrusterManagerROS {
   using ThrusterEffortVector = ThrusterAllocator::ThrusterEffortVector;
 
   ThrusterManagerROS(const ros::NodeHandle &nh)
-      : nh_{nh}, allocator_{ros::NodeHandle{"~"}} {
+      : nh_{nh}, allocator_{ros::NodeHandle{"~"}}, 
+        tf_buffer_{}, tf_listener_{tf_buffer_} {
     ROS_INFO("ThrusterManagerROS initialized");
 
     ros::NodeHandle nh_private("~");
@@ -28,6 +32,8 @@ class ThrusterManagerROS {
     nh_private.getParam("mapping", mapping_);
     nh_private.getParam("max_thrust", max_wrench_);
     nh_private.getParam("min_thrust", min_wrench_);
+    nh_private.param<std::string>("body_frame", body_frame_, "taluy/base_link");
+    nh_private.param<double>("transform_timeout", transform_timeout_, 1.0);
 
     for (size_t i = 0; i < kThrusterCount; ++i) {
       thruster_wrench_pubs_[i] = nh_.advertise<geometry_msgs::WrenchStamped>(
@@ -54,8 +60,35 @@ class ThrusterManagerROS {
         rate.sleep();
         continue;
       }
+      
       const auto wrench_msg = latest_wrench_.value();
-      auto thruster_efforts = allocator_.allocate(to_vector(wrench_msg));
+      
+      // Transform wrench if frame_id is provided
+      geometry_msgs::WrenchStamped transformed_wrench = wrench_msg;
+      if (!wrench_msg.header.frame_id.empty() && 
+          wrench_msg.header.frame_id != body_frame_) {
+        try {
+          // Check if transform is available
+          tf_buffer_.canTransform(body_frame_, wrench_msg.header.frame_id, 
+                                  ros::Time(0), ros::Duration(transform_timeout_));
+          
+          // Transform the wrench
+          tf2::doTransform(wrench_msg, transformed_wrench, 
+                           tf_buffer_.lookupTransform(body_frame_, 
+                                                      wrench_msg.header.frame_id, 
+                                                      ros::Time(0)));
+        } catch (const tf2::TransformException& ex) {
+          ROS_WARN_STREAM("Could not transform wrench from " 
+                          << wrench_msg.header.frame_id 
+                          << " to " << body_frame_ 
+                          << ": " << ex.what());
+          ros::spinOnce();
+          rate.sleep();
+          continue;
+        }
+      }
+
+      auto thruster_efforts = allocator_.allocate(to_vector(transformed_wrench.wrench));
       allocator_.get_wrench_stamped_vector(thruster_efforts.value(),
                                            thruster_wrench_msgs_);
 
@@ -86,8 +119,8 @@ class ThrusterManagerROS {
  private:
   WrenchVector to_vector(const geometry_msgs::Wrench &wrench) {
     WrenchVector vector;
-    vector << wrench.force.x, wrench.force.y, wrench.force.z, wrench.torque.x,
-        wrench.torque.y, wrench.torque.z;
+    vector << wrench.force.x, wrench.force.y, wrench.force.z, 
+              wrench.torque.x, wrench.torque.y, wrench.torque.z;
     return vector;
   }
 
@@ -95,7 +128,7 @@ class ThrusterManagerROS {
     return (ros::Time::now() - latest_wrench_time_).toSec() > 1.0;
   }
 
-  void wrench_callback(const geometry_msgs::Wrench &msg) {
+  void wrench_callback(const geometry_msgs::WrenchStamped &msg) {
     latest_wrench_ = msg;
     latest_wrench_time_ = ros::Time::now();
   }
@@ -121,8 +154,8 @@ class ThrusterManagerROS {
 
   uint16_t calculate_drive_value(const std::vector<double> &coeffs,
                                  double wrench, double voltage) const {
-    double a = coeffs[0], b = coeffs[1], c = coeffs[2], d = coeffs[3],
-           e = coeffs[4], f = coeffs[5];
+    double a = coeffs[0], b = coeffs[1], c = coeffs[2], 
+           d = coeffs[3], e = coeffs[4], f = coeffs[5];
     double drive_value = a * wrench * wrench + b * wrench * voltage +
                          c * voltage * voltage + d * wrench + e * voltage + f;
     return static_cast<uint16_t>(drive_value);
@@ -130,7 +163,7 @@ class ThrusterManagerROS {
 
   ros::NodeHandle nh_;
   ThrusterAllocator allocator_;
-  std::optional<geometry_msgs::Wrench> latest_wrench_;
+  std::optional<geometry_msgs::WrenchStamped> latest_wrench_;
   std::optional<auv_msgs::Power> latest_power_;
   ros::Time latest_wrench_time_{ros::Time(0)};
   std::array<ros::Publisher, kThrusterCount> thruster_wrench_pubs_;
@@ -139,6 +172,12 @@ class ThrusterManagerROS {
   ros::Subscriber wrench_sub_;
   ros::Subscriber power_sub_;
   ros::Publisher drive_pub_;
+
+  // TF related members
+  tf2_ros::Buffer tf_buffer_;
+  tf2_ros::TransformListener tf_listener_;
+  std::string body_frame_;
+  double transform_timeout_;
 
   std::vector<double> coeffs_ccw_;
   std::vector<double> coeffs_cw_;


### PR DESCRIPTION
Updated the controller_ros.h to publish WrenchStamped message type instead of Wrench to be able to subscribe in thruster_manager_ros.h and deal with transformation to the body frame and using it as is. Also tested in the simulation. This pr is updated version of old one #76 .