### PR TITLE
teleop xbox controller

### DIFF
--- a/auv_teleop/config/xbox.yaml
+++ b/auv_teleop/config/xbox.yaml
@@ -1,0 +1,20 @@
+---
+buttons:
+  launch_torpedo1: 4
+  launch_torpedo2: 5
+  drop_ball: 3
+  z_control: 0
+
+axes:
+  x_axis:
+    index: [1, 7]
+    gain: 0.4
+  y_axis:
+    index: [0, 6]
+    gain: 0.4
+  z_axis:
+    index: [1, 7]
+    gain: 0.4
+  yaw_axis:
+    index: [3]
+    gain: 0.5

--- a/auv_teleop/config/xbox.yaml
+++ b/auv_teleop/config/xbox.yaml
@@ -1,9 +1,14 @@
 ---
 buttons:
-  launch_torpedo1: 4
-  launch_torpedo2: 5
+  launch_torpedo1: 2
+  launch_torpedo2: 1
   drop_ball: 3
-  z_control: 0
+  +z_axis:
+    index: 5
+    gain: 0.4
+  -z_axis:
+    index: 4
+    gain: 0.4
 
 axes:
   x_axis:
@@ -11,9 +16,6 @@ axes:
     gain: 0.4
   y_axis:
     index: [0, 6]
-    gain: 0.4
-  z_axis:
-    index: [1, 7]
     gain: 0.4
   yaw_axis:
     index: [3]

--- a/auv_teleop/config/xbox.yaml
+++ b/auv_teleop/config/xbox.yaml
@@ -3,10 +3,10 @@ buttons:
   launch_torpedo1: 2
   launch_torpedo2: 1
   drop_ball: 3
-  +z_axis:
+  z_axis_pos:
     index: 5
     gain: 0.4
-  -z_axis:
+  z_axis_neg:
     index: 4
     gain: 0.4
 

--- a/auv_teleop/scripts/joy_manager.py
+++ b/auv_teleop/scripts/joy_manager.py
@@ -95,6 +95,11 @@ class JoystickNode:
                 self.joy_data.buttons[self.buttons["drop_ball"]]
             )
 
+    def get_axis_value(self, indices):
+        if isinstance(indices, list):
+            return sum(self.joy_data.axes[i] for i in indices)
+        return self.joy_data.axes[indices]
+
     def run(self):
         while not rospy.is_shutdown():
             twist = Twist()
@@ -105,22 +110,22 @@ class JoystickNode:
                     if self.joy_data.buttons[self.buttons["z_control"]]:
                         twist.linear.x = 0.0
                         twist.linear.z = (
-                            self.joy_data.axes[self.axes["z_axis"]["index"]]
+                            self.get_axis_value(self.axes["z_axis"]["index"])
                             * self.axes["z_axis"]["gain"]
                         )
                     else:
                         twist.linear.x = (
-                            self.joy_data.axes[self.axes["x_axis"]["index"]]
+                            self.get_axis_value(self.axes["x_axis"]["index"])
                             * self.axes["x_axis"]["gain"]
                         )
                         twist.linear.z = 0.0
 
                     twist.linear.y = (
-                        self.joy_data.axes[self.axes["y_axis"]["index"]]
+                        self.get_axis_value(self.axes["y_axis"]["index"])
                         * self.axes["y_axis"]["gain"]
                     )
                     twist.angular.z = (
-                        self.joy_data.axes[self.axes["yaw_axis"]["index"]]
+                        self.get_axis_value(self.axes["yaw_axis"]["index"])
                         * self.axes["yaw_axis"]["gain"]
                     )
                 else:
@@ -138,3 +143,4 @@ if __name__ == "__main__":
         joystick_node.run()
     except rospy.ROSInterruptException:
         pass
+

--- a/auv_teleop/scripts/joy_manager.py
+++ b/auv_teleop/scripts/joy_manager.py
@@ -143,4 +143,3 @@ if __name__ == "__main__":
         joystick_node.run()
     except rospy.ROSInterruptException:
         pass
-

--- a/auv_teleop/scripts/joy_manager.py
+++ b/auv_teleop/scripts/joy_manager.py
@@ -102,14 +102,14 @@ class JoystickNode:
 
     def get_z_axis_value(self):
         # Check if using Xbox controller configuration (with +/- z buttons)
-        if "+z_axis" in self.buttons and "-z_axis" in self.buttons:
+        if "z_axis_pos" in self.buttons and "z_axis_neg" in self.buttons:
             pos_value = (
-                self.joy_data.buttons[self.buttons["+z_axis"]["index"]]
-                * self.buttons["+z_axis"]["gain"]
+                self.joy_data.buttons[self.buttons["z_axis_pos"]["index"]]
+                * self.buttons["z_axis_pos"]["gain"]
             )
             neg_value = (
-                self.joy_data.buttons[self.buttons["-z_axis"]["index"]]
-                * self.buttons["-z_axis"]["gain"]
+                self.joy_data.buttons[self.buttons["z_axis_neg"]["index"]]
+                * self.buttons["z_axis_neg"]["gain"]
             )
             return pos_value - neg_value
         # Check if using Joy controller configuration (with z_control button)


### PR DESCRIPTION
The purpose of this pr is that sometimes we have difficulty controlling the vehicle with the joystick in the tests, for instance, we want to move the vehicle only x or y axis, but when we do this with the joystick, we unintentionally make different movements. With this pr, as can be seen in the image, we will be able top drive these two axes with both the joystick part of the xbox controller and with the arrow keys, while we can drive in a single axis with the arrow keys indicated in red.


![WhatsApp Image 2025-01-30 at 15 00 16](https://github.com/user-attachments/assets/d2a3f556-9ae8-4b4a-8dba-fdfa9d149b8f)

