### PR TITLE
add birds eye camera to sim

### DIFF
--- a/auv_sim/auv_sim_description/auv_sim_description/worlds/pool.world
+++ b/auv_sim/auv_sim_description/auv_sim_description/worlds/pool.world
@@ -365,5 +365,59 @@
         <kinematic>0</kinematic>
       </link>
     </model>
+    <!-- Pool overhead camera model -->
+    <model name="pool_camera">
+      <static>true</static>
+      <pose>0.3 -11 10 0 1.5708 0</pose>
+      <link name="pool_camera_link">
+        <pose>0 0 0 0 0 0</pose>
+        <visual name="camera_visual">
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.1</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.1 0.1 0.1 1</ambient>
+            <diffuse>0.1 0.1 0.1 1</diffuse>
+          </material>
+        </visual>
+        <sensor name="camera_sensor" type="camera">
+          <update_rate>30.0</update_rate>
+          <camera name="pool_camera">
+            <horizontal_fov>1.36136</horizontal_fov>
+            <image>
+              <width>640</width>
+              <height>480</height>
+              <format>B8G8R8</format>
+            </image>
+            <clip>
+              <near>0.02</near>
+              <far>300</far>
+            </clip>
+            <noise>
+              <type>gaussian</type>
+              <mean>0.0</mean>
+              <stddev>0.007</stddev>
+            </noise>
+          </camera>
+          <plugin name="camera_controller" filename="libgazebo_ros_camera.so">
+            <alwaysOn>true</alwaysOn>
+            <updateRate>30.0</updateRate>
+            <cameraName>pool_camera</cameraName>
+            <imageTopicName>image_raw</imageTopicName>
+            <cameraInfoTopicName>camera_info</cameraInfoTopicName>
+            <frameName>pool_camera_link</frameName>
+            <hackBaseline>0.07</hackBaseline>
+            <distortionK1>0.0</distortionK1>
+            <distortionK2>0.0</distortionK2>
+            <distortionK3>0.0</distortionK3>
+            <distortionT1>0.0</distortionT1>
+            <distortionT2>0.0</distortionT2>
+          </plugin>
+        </sensor>
+      </link>
+    </model>
+
   </world>
 </sdf>


### PR DESCRIPTION
When we started the simulation with use_gui:= 0 to give our computer better performance, we needed to add a bird's eye view camera to the simulation because we thought it would be useful.