### PR TITLE
Emin: add: new path planning framework and path planner for gate task

### DIFF
--- a/auv_navigation/auv_navigation/src/auv_navigation/path_planners.py
+++ b/auv_navigation/auv_navigation/src/auv_navigation/path_planners.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+import rospy
+import tf2_ros
+import tf
+import numpy as np
+from nav_msgs.msg import Path
+from geometry_msgs.msg import PoseStamped
+from typing import Optional, List
+from auv_navigation.path_planning_utils import PathPlanningHelper
+
+DEFAULT_HEADER_FRAME: str = "odom"
+BASE_LINK_FRAME: str = "taluy/base_link"
+GATE_ENTRANCE_FRAME: str = "gate_enterance"  #TODO (somebody) fix the typo: enterance -> entrance
+GATE_EXIT_FRAME: str = "gate_exit"
+
+class PathPlanners:
+    def __init__(self, tf_buffer: tf2_ros.Buffer):
+        self.tf_buffer = tf_buffer
+        
+    def straight_path_to_frame(
+        self,
+        source_frame: str,
+        target_frame: str,
+        angle_offset: float = 0.0,
+        num_waypoints: int = 50,
+        n_turns: int = 0,
+        interpolate_xy: bool = True,
+        interpolate_z: bool = True,
+        interpolate_yaw: bool = True,
+    ) -> Optional[Path]:
+        """
+        Creates a straight path from source frame to target frame.
+
+        Args:
+            source_frame: The starting frame.
+            target_frame: The destination frame.
+            angle_offset: Additional angle offset (in radians) to add to the target orientation.
+            num_waypoints: Number of waypoints to generate.
+            n_turns: Number of full 360-degree turns to add to the interpolation.
+            interpolate_xy: If True, interpolate the x and y positions.
+            interpolate_z: If True, interpolate the z position.
+            interpolate_yaw: If True, interpolate the yaw orientation.
+
+        Returns:
+            A Path message if successful, otherwise None.
+        """
+        try:
+            # Lookup transforms and extract positions and quaternions.
+            source_position, source_quaternion = PathPlanningHelper.lookup_transform(
+                self.tf_buffer, source_frame
+            )
+            target_position, target_quaternion = PathPlanningHelper.lookup_transform(
+                self.tf_buffer, target_frame
+            )
+
+            # Apply angle_offset to the target quaternion.
+            final_target_quat = PathPlanningHelper.apply_angle_offset(target_quaternion, angle_offset)
+
+            # Get euler of source and target.
+            source_euler = tf.transformations.euler_from_quaternion(source_quaternion)
+            final_target_euler = tf.transformations.euler_from_quaternion(final_target_quat)
+            
+            # Compute the angular difference (yaw only).
+            angular_diff = PathPlanningHelper.compute_angular_difference(
+                source_euler, final_target_euler, n_turns
+            )
+
+            # Create a header for the path.
+            header = PathPlanningHelper.create_path_header(DEFAULT_HEADER_FRAME)
+
+            # Generate waypoints using the provided interpolation flags.
+            poses = PathPlanningHelper.generate_waypoints(
+                header,
+                source_position,
+                target_position,
+                source_euler,
+                angular_diff,
+                num_waypoints,
+                interpolate_xy,
+                interpolate_z,
+                interpolate_yaw,
+            )
+
+            # Create and return the final Path message.
+            return PathPlanningHelper.create_path_from_poses(header, poses)
+
+        except Exception as e:
+            rospy.logerr(f"Error in straight_path_to_frame: {e}")
+            return None
+
+    def path_for_gate(self, path_creation_timeout: float = 10.0
+    ) -> Optional[List[Path]]:
+        """
+        Plans paths for the gate task, which includes the two paths:
+        2. path to gate entrance
+        2. Gate entrance to gate exit (with 1 360 degrees turn)
+        """
+        try:
+            rospy.logdebug("[GatePathPlanner] Planning paths for gate task...")
+            start_time = rospy.Time.now()
+            # Plan path to gate entrance
+            entrance_path = None
+            exit_path = None
+            
+            while (rospy.Time.now() - start_time).to_sec() < path_creation_timeout:
+                try:
+                    # create the first segment
+                    if entrance_path is None:
+                        entrance_path = self.straight_path_to_frame(
+                            source_frame=BASE_LINK_FRAME,
+                            target_frame=GATE_ENTRANCE_FRAME
+                        )
+                    #create the second segment
+                    if exit_path is None:
+                        exit_path = self.straight_path_to_frame(
+                            source_frame=GATE_ENTRANCE_FRAME,
+                            target_frame=GATE_EXIT_FRAME,
+                            n_turns=1
+                        )
+                    if entrance_path is not None and exit_path is not None:
+                        return [entrance_path, exit_path]
+                    rospy.logwarn("[GatePathPlanner] Failed to plan paths, retrying... Time elapsed: %.1f seconds", 
+                                (rospy.Time.now() - start_time).to_sec())
+                    rospy.sleep(0.5)
+                    
+                except (tf2_ros.LookupException, 
+                        tf2_ros.ConnectivityException, 
+                        tf2_ros.ExtrapolationException) as e:
+                    rospy.logwarn("[GatePathPlanner] TF error while planning paths: %s. Retrying...", str(e))
+                    rospy.sleep(0.5)
+            
+            # If we get here, we timed out
+            rospy.logwarn("[GatePathPlanner] Failed to plan paths after %.1f seconds", path_creation_timeout)
+            return None
+            
+        except Exception as e:
+            rospy.logwarn("[GatePathPlanner] Error in gate path planning: %s", str(e))
+            return None

--- a/auv_navigation/auv_navigation/src/auv_navigation/path_planning_utils.py
+++ b/auv_navigation/auv_navigation/src/auv_navigation/path_planning_utils.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+import rospy
+import tf2_ros
+import tf
+import numpy as np
+from nav_msgs.msg import Path
+from geometry_msgs.msg import PoseStamped
+from typing import Optional
+
+DEFAULT_FIXED_FRAME: str = "odom"
+DEFAULT_FRAME_ID: str = "odom"
+TIME_ZERO = rospy.Time(0)
+TF_LOOKUP_TIMEOUT = rospy.Duration(1.0)
+TWO_PI: float = 2 * np.pi
+
+class PathPlanningHelper:
+    """Helper class containing static methods for path creation."""
+
+    @staticmethod
+    def lookup_transform(tf_buffer: tf2_ros.Buffer, frame: str, fixed_frame: str = DEFAULT_FIXED_FRAME):
+        """
+        Looks up the transform for the given frame and returns its position and quaternion.
+
+        Returns:
+            (position, quaternion)
+        """
+        transform = tf_buffer.lookup_transform(
+            fixed_frame, frame, TIME_ZERO, TF_LOOKUP_TIMEOUT
+        )
+        position = transform.transform.translation
+        quaternion = [
+            transform.transform.rotation.x,
+            transform.transform.rotation.y,
+            transform.transform.rotation.z,
+            transform.transform.rotation.w,
+        ]
+        return position, quaternion
+
+    @staticmethod
+    def apply_angle_offset(quaternion, angle_offset: float):
+        """
+        Applies an angle offset (in radians) to the given quaternion.
+
+        Returns:
+            The resulting quaternion after applying the offset.
+        """
+        offset_quat = tf.transformations.quaternion_from_euler(0, 0, angle_offset)
+        return tf.transformations.quaternion_multiply(offset_quat, quaternion)
+
+    @staticmethod
+    def compute_angular_difference(source_euler, target_euler, n_turns: int):
+        """
+        Computes the yaw angular difference between the source and target orientations,
+        adding extra full 360° turns if requested.
+
+        Returns:
+            angular_diff: The yaw difference (including extra turns) between target and source in radians.
+        """
+        angular_diff = (target_euler[2] - source_euler[2]) + (TWO_PI * n_turns)
+        return angular_diff
+
+    @staticmethod
+    def interpolate_position(source_pos, target_pos, t: float, interpolate_xy: bool = True, interpolate_z: bool = True):
+        """
+        Linearly interpolates between two positions given a factor t [0,1]
+
+        Args:
+            source_pos: The starting position.
+            target_pos: The ending position.
+            t: Interpolation factor (0.0 to 1.0).
+            interpolate_xy: If True, interpolate x and y; otherwise, keep source x and y.
+            interpolate_z: If True, interpolate z; otherwise, keep source z.
+
+        Returns:
+            A new position with interpolated values for the selected components.
+        """
+        interp_pos = type(source_pos)()  # Create a new instance of the position type.
+        if interpolate_xy:
+            interp_pos.x = source_pos.x + t * (target_pos.x - source_pos.x)
+            interp_pos.y = source_pos.y + t * (target_pos.y - source_pos.y)
+        else:
+            interp_pos.x = source_pos.x
+            interp_pos.y = source_pos.y
+
+        if interpolate_z:
+            interp_pos.z = source_pos.z + t * (target_pos.z - source_pos.z)
+        else:
+            interp_pos.z = source_pos.z
+
+        return interp_pos
+
+    @staticmethod
+    def interpolate_orientation(source_euler, angular_diff: float, t: float, interpolate_yaw: bool = True):
+        """
+        Interpolates the yaw component between the source and target orientations based on the flag.
+
+        Roll and pitch are taken from the source.
+
+        Args:
+            source_euler: Euler angles of source.
+            angular_diff: The yaw difference between target and source (with extra turns).
+            t: Interpolation factor (0.0 to 1.0).
+            interpolate_yaw: If True, interpolate yaw; otherwise, keep source yaw.
+
+        Returns:
+            A quaternion representing the interpolated orientation.
+        """
+        roll = source_euler[0]
+        pitch = source_euler[1]
+        if interpolate_yaw:
+            new_yaw = source_euler[2] + t * angular_diff
+        else:
+            new_yaw = source_euler[2]
+        return tf.transformations.quaternion_from_euler(roll, pitch, new_yaw)
+
+    @staticmethod
+    def generate_waypoints(header, source_position, target_position, source_euler,
+                           angular_diff: float, num_waypoints: int,
+                           interpolate_xy: bool, interpolate_z: bool, interpolate_yaw: bool):
+        """
+        Generates a list of PoseStamped waypoints interpolated between the source and target.
+
+        Returns:
+            A list of PoseStamped messages.
+        """
+        poses = []
+        for t in np.linspace(0, 1, num_waypoints):
+            pose = PoseStamped()
+            pose.header = header
+
+            # Interpolate position based on flags.
+            interp_pos = PathPlanningHelper.interpolate_position(
+                source_position, target_position, t, interpolate_xy, interpolate_z
+            )
+            pose.pose.position.x = interp_pos.x
+            pose.pose.position.y = interp_pos.y
+            pose.pose.position.z = interp_pos.z
+
+            # Interpolate orientation (yaw) based on flag.
+            interp_quat = PathPlanningHelper.interpolate_orientation(
+                source_euler, angular_diff, t, interpolate_yaw
+            )
+            pose.pose.orientation.x = interp_quat[0]
+            pose.pose.orientation.y = interp_quat[1]
+            pose.pose.orientation.z = interp_quat[2]
+            pose.pose.orientation.w = interp_quat[3]
+
+            poses.append(pose)
+        return poses
+
+    @staticmethod
+    def create_path_header(frame_id: str) -> rospy.Header: 
+        """
+        Creates header for the Path message.
+        """
+        header = rospy.Header()
+        header.frame_id = frame_id
+        header.stamp = rospy.Time.now()
+        return header
+
+    @staticmethod
+    def create_path_from_poses(header, poses):
+        """
+        Creates a Path message given a header and list of PoseStamped poses.
+        """
+        path = Path()
+        path.header = header
+        path.poses = poses
+        return path
+    
+
+
+    
+


### PR DESCRIPTION
This PR adds a structured path planning framework, introducing the two new modules:

1. **`path_planners.py`**  
   -  the `PathPlanners` class for high-level path planning.  
   - Methods:  
     - **`straight_path_to_frame(...)`**: Generates a straight-line path between two TF frames. This function is very customizable to different scenarious like:
       - Select whether to interpolate position (X/Y, Z) and yaw  (if not, use the source values along the path)
       - Optional 360-degree rotations (`n_turns`)  
       - Additional `angle offset` (in radians) to add to the target orientation.
       This solves #126 by collecting all the helper functions to module 2.

     - **`path_for_gate(...)`**: Plans a two-segment path for the gate task.
       - From base link to the gate entrance  
       - From the entrance to the exit, adding a full turn.  

2. **`path_planning_utils.py`**  
   - Provides the `PathPlanningHelper` class. Details of functions can be found in code.