### PR TITLE
WIP: enhance: new gate smach with follow_path action server integration

### DIFF
--- a/auv_navigation/auv_navigation/src/auv_navigation/follow_path_action_client.py
+++ b/auv_navigation/auv_navigation/src/auv_navigation/follow_path_action_client.py
@@ -4,10 +4,14 @@ import actionlib
 from auv_msgs.msg import FollowPathAction, FollowPathGoal
 from typing import List
 from nav_msgs.msg import Path
+
+
 class FollowPathActionClient:
     def __init__(self):
-        self.client = actionlib.SimpleActionClient("taluy/follow_path", FollowPathAction)
-        
+        self.client = actionlib.SimpleActionClient(
+            "taluy/follow_path", FollowPathAction
+        )
+
         rospy.logdebug("[follow_path client] waiting for action server...")
         self.client.wait_for_server()
         rospy.logdebug("[follow_path client] action server is up!")
@@ -22,7 +26,7 @@ class FollowPathActionClient:
         """
         try:
             goal = FollowPathGoal()
-            #goal.paths = [path for path in paths] #! necessary??
+            # goal.paths = [path for path in paths] #! necessary??
             goal.paths = paths
             rospy.logdebug("[follow_path client] sending paths goal...")
             self.client.send_goal(goal)
@@ -30,9 +34,12 @@ class FollowPathActionClient:
             rospy.logdebug("[follow_path client] Waiting for result...")
             self.client.wait_for_result()
             result = self.client.get_result()
-            
+
             if result and result.success:
-                rospy.logdebug("[follow_path client] Task succeeded: execution time: %.2f seconds", result.execution_time)
+                rospy.logdebug(
+                    "[follow_path client] Task succeeded: execution time: %.2f seconds",
+                    result.execution_time,
+                )
                 return True
             else:
                 rospy.logwarn("[follow_path client] Task failed")

--- a/auv_navigation/auv_navigation/src/auv_navigation/follow_path_action_client.py
+++ b/auv_navigation/auv_navigation/src/auv_navigation/follow_path_action_client.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+import rospy
+import actionlib
+from auv_msgs.msg import FollowPathAction, FollowPathGoal
+from typing import List
+from nav_msgs.msg import Path
+class FollowPathActionClient:
+    def __init__(self):
+        self.client = actionlib.SimpleActionClient("taluy/follow_path", FollowPathAction)
+        
+        rospy.logdebug("[follow_path client] Waiting for action server...")
+        if not self.client.wait_for_server(rospy.Duration(10)):
+            rospy.logerr("[follow_path client] Action server not available after waiting")
+            raise rospy.ROSException("Action server not available")
+        rospy.logdebug("[follow_path client] Action server is up!")
+
+    def execute_paths(self, paths: List[Path]) -> bool:
+        """
+        Sends a lists of Path messages to the follow_path action server for execution.
+        Args:
+            paths: List of Path messages to execute
+        Returns:
+            bool: True if execution completes successfully (server returns SUCCESS), False otherwise.
+        """
+        try:
+            goal = FollowPathGoal()
+            #goal.paths = [path for path in paths] #! necessary??
+            goal.paths = paths
+            rospy.logdebug("[follow_path client] sending paths goal...")
+            self.client.send_goal(goal)
+
+            rospy.logdebug("[follow_path client] Waiting for result...")
+            self.client.wait_for_result()
+            result = self.client.get_result()
+            
+            if result and result.success:
+                rospy.logdebug("[follow_path client] Task succeeded: execution time: %.2f seconds", result.execution_time)
+                return True
+            else:
+                rospy.logwarn("[follow_path client] Task failed")
+                return False
+
+        except Exception as e:
+            rospy.logerr("[follow_path client] Error executing paths: %s", str(e))
+            return False

--- a/auv_navigation/auv_navigation/src/auv_navigation/follow_path_action_client.py
+++ b/auv_navigation/auv_navigation/src/auv_navigation/follow_path_action_client.py
@@ -8,11 +8,9 @@ class FollowPathActionClient:
     def __init__(self):
         self.client = actionlib.SimpleActionClient("taluy/follow_path", FollowPathAction)
         
-        rospy.logdebug("[follow_path client] Waiting for action server...")
-        if not self.client.wait_for_server(rospy.Duration(10)):
-            rospy.logerr("[follow_path client] Action server not available after waiting")
-            raise rospy.ROSException("Action server not available")
-        rospy.logdebug("[follow_path client] Action server is up!")
+        rospy.logdebug("[follow_path client] waiting for action server...")
+        self.client.wait_for_server()
+        rospy.logdebug("[follow_path client] action server is up!")
 
     def execute_paths(self, paths: List[Path]) -> bool:
         """

--- a/auv_smach/src/auv_smach/common.py
+++ b/auv_smach/src/auv_smach/common.py
@@ -1,24 +1,17 @@
 import smach
 import smach_ros
 import rospy
-from std_srvs.srv import SetBool, SetBoolRequest, SetBoolResponse
-from std_srvs.srv import Trigger, TriggerRequest, TriggerResponse
-from robot_localization.srv import SetPose, SetPoseRequest, SetPoseResponse
-from auv_msgs.srv import (
-    SetObjectTransform,
-    SetObjectTransformRequest,
-    SetObjectTransformResponse,
-    AlignFrameController,
-    AlignFrameControllerRequest,
-    AlignFrameControllerResponse,
-)
+import threading
+import numpy as np
+import tf2_ros
+import tf.transformations as transformations
+
+from std_srvs.srv import Trigger, TriggerRequest
+from auv_msgs.srv import AlignFrameController, AlignFrameControllerRequest
 from std_msgs.msg import Bool
 from geometry_msgs.msg import TransformStamped
-import tf2_ros
-import numpy as np
-import tf.transformations as transformations
-import tf2_geometry_msgs
-from auv_msgs.srv import SetDepth, SetDepthRequest, SetDepthResponse
+from auv_msgs.srv import SetDepth, SetDepthRequest
+from auv_navigation import follow_path_action_client
 
 from tf.transformations import (
     quaternion_matrix,
@@ -73,6 +66,7 @@ def concatenate_transforms(transform1, transform2):
     combined_matrix = multiply_transforms(transform1.transform, transform2.transform)
     return matrix_to_transform(combined_matrix)
 
+# ------------------- STATES -------------------
 
 class SetDepthState(smach_ros.ServiceState):
     def __init__(self, depth: float, sleep_duration=0.0):

--- a/auv_smach/src/auv_smach/common.py
+++ b/auv_smach/src/auv_smach/common.py
@@ -66,7 +66,9 @@ def concatenate_transforms(transform1, transform2):
     combined_matrix = multiply_transforms(transform1.transform, transform2.transform)
     return matrix_to_transform(combined_matrix)
 
+
 # ------------------- STATES -------------------
+
 
 class SetDepthState(smach_ros.ServiceState):
     def __init__(self, depth: float, sleep_duration=0.0):
@@ -244,19 +246,23 @@ class NavigateToFrameState(smach.State):
         ) as e:
             rospy.logwarn(f"TF lookup exception: {e}")
             return "aborted"
-            
+
+
 class ExecutePlannedPathsState(smach.State):
     """
     Uses the follow path action client to follow a set of planned paths.
     """
+
     def __init__(self):
-            smach.State.__init__(
-                self,
-                outcomes=["succeeded", "preempted", "aborted"],
-                input_keys=["planned_paths"] # expects the input value under the name "planned_paths"
-            )
-            self._client = None
-    
+        smach.State.__init__(
+            self,
+            outcomes=["succeeded", "preempted", "aborted"],
+            input_keys=[
+                "planned_paths"
+            ],  # expects the input value under the name "planned_paths"
+        )
+        self._client = None
+
     def execute(self, userdata) -> str:
         """
         Args:
@@ -266,9 +272,11 @@ class ExecutePlannedPathsState(smach.State):
             str: "succeeded" if execution was successful, otherwise "aborted" or "preempted".
         """
         if self._client is None:
-            rospy.logdebug("[ExecutePlannedPathsState] Initializing the FollowPathActionClient")
+            rospy.logdebug(
+                "[ExecutePlannedPathsState] Initializing the FollowPathActionClient"
+            )
             self._client = follow_path_action_client.FollowPathActionClient()
-        
+
         # Check for preemption before proceeding
         if self.preempt_requested():
             rospy.logwarn("[ExecutePlannedPathsState] Preempt requested")
@@ -277,12 +285,16 @@ class ExecutePlannedPathsState(smach.State):
             planned_paths = userdata.planned_paths
             success = self._client.execute_paths(planned_paths)
             if success:
-                rospy.logdebug("[ExecutePlannedPathsState] Planned paths executed successfully")
+                rospy.logdebug(
+                    "[ExecutePlannedPathsState] Planned paths executed successfully"
+                )
                 return "succeeded"
             else:
-                rospy.logwarn("[ExecutePlannedPathsState] Execution of planned paths failed")
+                rospy.logwarn(
+                    "[ExecutePlannedPathsState] Execution of planned paths failed"
+                )
                 return "aborted"
-            
+
         except Exception as e:
             rospy.logerr("[ExecutePlannedPathsState] Exception occurred: %s", str(e))
             return "aborted"

--- a/auv_smach/src/auv_smach/gate.py
+++ b/auv_smach/src/auv_smach/gate.py
@@ -1,41 +1,51 @@
 from .initialize import *
 import smach
-import smach_ros
 import rospy
-from std_srvs.srv import SetBool, SetBoolRequest, SetBoolResponse
-from std_srvs.srv import Trigger, TriggerRequest, TriggerResponse
-from robot_localization.srv import SetPose, SetPoseRequest, SetPoseResponse
-from auv_msgs.srv import (
-    SetObjectTransform,
-    SetObjectTransformRequest,
-    SetObjectTransformResponse,
-    AlignFrameController,
-    AlignFrameControllerRequest,
-    AlignFrameControllerResponse,
-)
-from std_msgs.msg import Bool
-from geometry_msgs.msg import TransformStamped
 import tf2_ros
-import numpy as np
-import tf.transformations as transformations
-
+from auv_navigation.path_planners import PathPlanners
 from auv_smach.common import (
-    NavigateToFrameState,
     SetAlignControllerTargetState,
     CancelAlignControllerState,
     SetDepthState,
+    ExecutePlannedPathsState
 )
 
-from geometry_msgs.msg import Twist
-from std_msgs.msg import Bool
 
-from auv_smach.initialize import DelayState
+class PlanGatePathsState(smach.State):
+    """State that plans the paths for the gate task"""
+    def __init__(self, tf_buffer):
+        smach.State.__init__(
+            self, 
+            outcomes=["succeeded", "preempted", "aborted"],
+            output_keys=["planned_paths"]
+        )
+        self.tf_buffer = tf_buffer
 
+    def execute(self, userdata) -> str:
+        try:
+            if self.preempt_requested():
+                rospy.logwarn("[PlanGatePathsState] Preempt requested")
+                return "preempted"
+            
+            path_planners = PathPlanners(self.tf_buffer) # instance of PathPlanners with tf_buffer
+            paths = path_planners.path_for_gate()
+            if paths is None:
+                return "aborted"
+            
+            userdata.planned_paths = paths
+            return "succeeded"
+            
+        except Exception as e:
+            rospy.logerr("[PlanGatePathsState] Error: %s", str(e))
+            return "aborted"
 
 class NavigateThroughGateState(smach.State):
     def __init__(self, gate_depth: float):
         smach.State.__init__(self, outcomes=["succeeded", "preempted", "aborted"])
 
+        self.tf_buffer = tf2_ros.Buffer()
+        self.tf_listener = tf2_ros.TransformListener(self.tf_buffer)
+        
         # Initialize the state machine
         self.state_machine = smach.StateMachine(
             outcomes=["succeeded", "preempted", "aborted"]
@@ -45,7 +55,7 @@ class NavigateThroughGateState(smach.State):
         with self.state_machine:
             smach.StateMachine.add(
                 "SET_GATE_DEPTH",
-                SetDepthState(depth=gate_depth, sleep_duration=3.0),
+                SetDepthState(depth=gate_depth, sleep_duration=rospy.get_param("~set_depth_sleep_duration", 5.0)),
                 transitions={
                     "succeeded": "SET_ALIGN_CONTROLLER_TARGET",
                     "preempted": "preempted",
@@ -53,53 +63,52 @@ class NavigateThroughGateState(smach.State):
                 },
             )
             smach.StateMachine.add(
+                "PLAN_GATE_PATHS",
+                PlanGatePathsState(self.tf_buffer),
+                transitions={
+                    "succeeded": "EXECUTE_GATE_PATHS",
+                    "preempted": "preempted",
+                    "aborted": "aborted",
+                },
+            )
+            smach.StateMachine.add(
                 "SET_ALIGN_CONTROLLER_TARGET",
                 SetAlignControllerTargetState(
-                    source_frame="taluy/base_link", target_frame="gate_target"
+                    source_frame="taluy/base_link", target_frame="dynamic_target"
                 ),
                 transitions={
-                    "succeeded": "NAVIGATE_TO_GATE_START",
+                    "succeeded": "PLAN_GATE_PATHS",
                     "preempted": "preempted",
                     "aborted": "aborted",
                 },
             )
             smach.StateMachine.add(
-                "NAVIGATE_TO_GATE_START",
-                NavigateToFrameState(
-                    "taluy/base_link", "gate_enterance", "gate_target"
-                ),
+                "EXECUTE_GATE_PATHS",
+                ExecutePlannedPathsState(),
                 transitions={
-                    "succeeded": "NAVIGATE_TO_GATE_EXIT",
-                    "preempted": "preempted",
-                    "aborted": "aborted",
+                    "succeeded": "CANCEL_ALIGN_CONTROLLER",
+                    "preempted": "CANCEL_ALIGN_CONTROLLER", # if aborted or preempted, cancel the alignment request
+                    "aborted": "CANCEL_ALIGN_CONTROLLER",  # to disable the controllers.
+                                                            
                 },
             )
             smach.StateMachine.add(
-                "NAVIGATE_TO_GATE_EXIT",
-                NavigateToFrameState(
-                    "gate_enterance", "gate_exit", "gate_target", n_turns=-1
-                ),
+                "CANCEL_ALIGN_CONTROLLER",
+                CancelAlignControllerState(),
                 transitions={
                     "succeeded": "succeeded",
                     "preempted": "preempted",
                     "aborted": "aborted",
                 },
             )
-            # smach.StateMachine.add(
-            #     "CANCEL_ALIGN_CONTROLLER",
-            #     CancelAlignControllerState(),
-            #     transitions={
-            #         "succeeded": "succeeded",
-            #         "preempted": "preempted",
-            #         "aborted": "aborted",
-            #     },
-            # )
 
     def execute(self, userdata):
+        rospy.logdebug("[NavigateThroughGateState] Starting state machine execution.")
+        
         # Execute the state machine
         outcome = self.state_machine.execute()
 
-        if outcome is None:
+        if outcome is None: # ctrl + c
             return "preempted"
-
+        # Return the outcome of the state machine
         return outcome


### PR DESCRIPTION
This PR improves the gate navigation state by utilizing the follow path action server for executing planned paths. Let me introduce the new players:

### 1. The action client: `follow_path_action_client.py`
It is time we introduce the action client for our server. It is pretty straighforward in the sense that the client is simply a python module which connects to the action server and transfers the given paths as goals. Then it returns the action server's result.
### 2. New State: `ExecutePlannedPathsState`
This new state in common module expects the input key "planned_paths". Then it calls the client function, and returns whatever client has returned (which returns whatever server has returned)
### 3. New State: `PlanGatePathsState`
This state uses the plan_for_gate() function (introduced in PR #127) to plan the path for gate task. Than it sends them as an input to `ExecutePlannedPathsState`