### PR TITLE
Integrate camera pose estimation to Mapping node with KF

### DIFF
--- a/auv_navigation/auv_mapping/launch/start.launch
+++ b/auv_navigation/auv_mapping/launch/start.launch
@@ -4,7 +4,7 @@
   <arg name="control_rate" default="10" />
   <arg name="static_frame" default="odom" />
 
-  <node pkg="auv_mapping" type="prop_transform_publisher.py" name="prop_transform_publisher"
+  <node pkg="auv_detection" type="camera_detection_pose_estimator.py" name="camera_detection_pose_estimator"
     output="screen" />
 
   <group ns="$(arg namespace)">

--- a/auv_navigation/auv_mapping/launch/start.launch
+++ b/auv_navigation/auv_mapping/launch/start.launch
@@ -1,13 +1,15 @@
 <?xml version="1.0"?>
 <launch>
-  <arg name="namespace" default="turquoise" />
+  <arg name="namespace" default="taluy" />
   <arg name="control_rate" default="10" />
   <arg name="static_frame" default="odom" />
 
-  <node pkg="auv_detection" type="camera_detection_pose_estimator.py" name="camera_detection_pose_estimator"
-    output="screen" />
 
   <group ns="$(arg namespace)">
+    <node pkg="auv_detection" type="camera_detection_pose_estimator.py" name="camera_detection_pose_estimator" output="screen">
+      <remap from="object_transform_updates" to="map/object_transform_updates" />
+    </node>
+
     <node pkg="auv_mapping" type="object_map_tf_server_node" name="object_map_tf_server_node">
       <param name="rate" value="$(arg control_rate)" />
       <param name="static_frame" value="$(arg static_frame)" />

--- a/auv_navigation/auv_mapping/launch/start.launch
+++ b/auv_navigation/auv_mapping/launch/start.launch
@@ -8,6 +8,7 @@
   <group ns="$(arg namespace)">
     <node pkg="auv_detection" type="camera_detection_pose_estimator.py" name="camera_detection_pose_estimator" output="screen">
       <remap from="object_transform_updates" to="map/object_transform_updates" />
+      <remap from="dvl/altitude" to="sensors/dvl/altitude" />
     </node>
 
     <node pkg="auv_mapping" type="object_map_tf_server_node" name="object_map_tf_server_node">

--- a/auv_smach/launch/start.launch
+++ b/auv_smach/launch/start.launch
@@ -40,6 +40,7 @@
             <remap from="propulsion_board/status" to="propulsion_board/status"/>
 
             <!-- common.py -->
+            <remap from="clear_object_transforms" to="map/clear_object_transforms"/>
             <remap from="torpedo_$(arg torpedo_id)/launch" to="actuators/torpedo_$(arg torpedo_id)/launch"/>
             <remap from="ball_dropper/drop" to="actuators/ball_dropper/drop"/>
             <remap from="align_frame/cancel" to="control/align_frame/cancel"/>

--- a/auv_smach/src/auv_smach/common.py
+++ b/auv_smach/src/auv_smach/common.py
@@ -284,6 +284,8 @@ class NavigateToFrameState(smach.State):
         ) as e:
             rospy.logwarn(f"TF lookup exception: {e}")
             return "aborted"
+
+
 class ClearObjectMapState(smach_ros.ServiceState):
     def __init__(self):
         smach_ros.ServiceState.__init__(

--- a/auv_smach/src/auv_smach/common.py
+++ b/auv_smach/src/auv_smach/common.py
@@ -284,3 +284,11 @@ class NavigateToFrameState(smach.State):
         ) as e:
             rospy.logwarn(f"TF lookup exception: {e}")
             return "aborted"
+class ClearObjectMapState(smach_ros.ServiceState):
+    def __init__(self):
+        smach_ros.ServiceState.__init__(
+            self,
+            "/taluy/map/clear_object_transforms",
+            Trigger,
+            request=TriggerRequest(),
+        )

--- a/auv_smach/src/auv_smach/common.py
+++ b/auv_smach/src/auv_smach/common.py
@@ -288,7 +288,7 @@ class ClearObjectMapState(smach_ros.ServiceState):
     def __init__(self):
         smach_ros.ServiceState.__init__(
             self,
-            "/taluy/map/clear_object_transforms",
+            "clear_object_transforms",
             Trigger,
             request=TriggerRequest(),
         )

--- a/auv_smach/src/auv_smach/initialize.py
+++ b/auv_smach/src/auv_smach/initialize.py
@@ -74,7 +74,6 @@ class ResetOdometryPoseState(smach_ros.ServiceState):
         )
 
 
-
 class SetStartFrameState(smach_ros.ServiceState):
     def __init__(self, frame_name: str):
         transform_request = SetObjectTransformRequest()

--- a/auv_smach/src/auv_smach/initialize.py
+++ b/auv_smach/src/auv_smach/initialize.py
@@ -6,7 +6,7 @@ from std_srvs.srv import Empty, EmptyRequest
 from robot_localization.srv import SetPose, SetPoseRequest
 from auv_msgs.srv import SetObjectTransform, SetObjectTransformRequest
 from std_msgs.msg import Bool
-from auv_smach.common import CancelAlignControllerState
+from auv_smach.common import CancelAlignControllerState, ClearObjectMapState
 from typing import Optional, Literal
 from dataclasses import dataclass
 
@@ -72,6 +72,7 @@ class ResetOdometryPoseState(smach_ros.ServiceState):
             SetPose,
             request=initial_pose_request,
         )
+
 
 
 class SetStartFrameState(smach_ros.ServiceState):
@@ -158,6 +159,15 @@ class InitializeState(smach.State):
             smach.StateMachine.add(
                 "DELAY_AFTER_RESET",
                 DelayState(delay_time=1.0),
+                transitions={
+                    "succeeded": "CLEAR_OBJECT_MAP",
+                    "preempted": "preempted",
+                    "aborted": "aborted",
+                },
+            )
+            smach.StateMachine.add(
+                "CLEAR_OBJECT_MAP",
+                ClearObjectMapState(),
                 transitions={
                     "succeeded": "SET_START_FRAME",
                     "preempted": "preempted",

--- a/auv_vision/auv_detection/CMakeLists.txt
+++ b/auv_vision/auv_detection/CMakeLists.txt
@@ -9,6 +9,10 @@ catkin_package()
 include_directories(
   ${catkin_INCLUDE_DIRS}
 )
+catkin_install_python(PROGRAMS
+  scripts/camera_detection_pose_estimator.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
 
 install(DIRECTORY
   launch

--- a/auv_vision/auv_detection/scripts/camera_detection_pose_estimator.py
+++ b/auv_vision/auv_detection/scripts/camera_detection_pose_estimator.py
@@ -2,7 +2,16 @@
 
 import rospy
 import math
-from geometry_msgs.msg import PointStamped, PoseArray, PoseStamped, Pose, TransformStamped, Transform, Vector3, Quaternion
+from geometry_msgs.msg import (
+    PointStamped,
+    PoseArray,
+    PoseStamped,
+    Pose,
+    TransformStamped,
+    Transform,
+    Vector3,
+    Quaternion,
+)
 from ultralytics_ros.msg import YoloResult
 from sensor_msgs.msg import Range
 from std_msgs.msg import Float32
@@ -235,7 +244,9 @@ class CameraDetectionNode:
                 transform_stamped_msg = TransformStamped()
                 transform_stamped_msg.header.stamp = rospy.Time.now()
                 transform_stamped_msg.header.frame_id = "odom"
-                transform_stamped_msg.child_frame_id = self.id_tf_map[camera_ns][detection_id]
+                transform_stamped_msg.child_frame_id = self.id_tf_map[camera_ns][
+                    detection_id
+                ]
 
                 transform_stamped_msg.transform.translation = Vector3(x, y, z)
                 transform_stamped_msg.transform.rotation = Quaternion(0, 0, 0, 1)
@@ -314,11 +325,12 @@ class CameraDetectionNode:
             transform_stamped_msg.header.frame_id = camera_frame
             transform_stamped_msg.child_frame_id = prop_name
 
-            transform_stamped_msg.transform.translation = Vector3(offset_x, offset_y, distance)
+            transform_stamped_msg.transform.translation = Vector3(
+                offset_x, offset_y, distance
+            )
             transform_stamped_msg.transform.rotation = Quaternion(0, 0, 0, 1)
 
             self.object_transform_pub.publish(transform_stamped_msg)
-
 
     def run(self):
         rospy.spin()

--- a/auv_vision/auv_detection/scripts/camera_detection_pose_estimator.py
+++ b/auv_vision/auv_detection/scripts/camera_detection_pose_estimator.py
@@ -150,11 +150,6 @@ class CameraDetectionNode:
             },
             "taluy/cameras/cam_bottom": {9: "bin/whole", 10: "bin/red", 11: "bin/blue"},
         }
-
-
-        # Publishers for detected object coordinates
-        # Publisher for detected object transforms
-
         # Subscribe to YOLO detections and altitude
         self.altitude = None
         rospy.Subscriber("dvl/altitude", Float32, self.altitude_callback)
@@ -206,7 +201,6 @@ class CameraDetectionNode:
         offset_x = math.tan(angles[0]) * distance * 1.0
         offset_y = math.tan(angles[1]) * distance * 1.0
 
-        # optical_camera_frame'de tanımlı iki nokta
         point1 = PointStamped()
         point1.header.frame_id = self.camera_frames[camera_ns]
         point1.point.x = 0
@@ -238,16 +232,6 @@ class CameraDetectionNode:
             )
             if intersection:
                 x, y, z = intersection
-                point_msg = PointStamped()
-                point_msg.header.frame_id = "odom"
-                point_msg.header.stamp = rospy.Time.now()
-                point_msg.point.x = x
-                point_msg.point.y = y
-                point_msg.point.z = z
-
-                # if detection_id in self.detection_pubs:
-                #     self.detection_pubs[detection_id].publish(point_msg)
-
                 transform_stamped_msg = TransformStamped()
                 transform_stamped_msg.header.stamp = rospy.Time.now()
                 transform_stamped_msg.header.frame_id = "odom"
@@ -296,7 +280,6 @@ class CameraDetectionNode:
             if detection_id not in self.id_tf_map[camera_ns]:
                 continue
 
-            # Eğer detection bin_whole ise (id=9), altitude projection kullan
             if detection_id == 9:
                 self.process_altitude_projection(detection, camera_ns)
                 continue
@@ -326,9 +309,6 @@ class CameraDetectionNode:
 
             offset_x = math.tan(angles[0]) * distance * 1.0
             offset_y = math.tan(angles[1]) * distance * 1.0
-            # # Publish point message
-            # if detection_id in self.detection_pubs:
-            #     self.detection_pubs[detection_id].publish(point_msg)
             transform_stamped_msg = TransformStamped()
             transform_stamped_msg.header.stamp = rospy.Time.now()
             transform_stamped_msg.header.frame_id = camera_frame

--- a/auv_vision/auv_detection/scripts/camera_detection_pose_estimator.py
+++ b/auv_vision/auv_detection/scripts/camera_detection_pose_estimator.py
@@ -126,22 +126,22 @@ class CameraDetectionNode:
         }
 
         self.props = {
-            "red_buoy": BuoyRed(),
-            "gate_red_arrow": GateRedArrow(),
-            "gate_blue_arrow": GateBlueArrow(),
-            "gate_middle_part": GateMiddlePart(),
-            "torpedo_map": TorpedoMap(),
-            "octagon": Octagon(),
+            "red_buoy_link": BuoyRed(),
+            "gate_red_arrow_link": GateRedArrow(),
+            "gate_blue_arrow_link": GateBlueArrow(),
+            "gate_middle_part_link": GateMiddlePart(),
+            "torpedo_map_link": TorpedoMap(),
+            "octagon_link": Octagon(),
         }
 
         self.id_tf_map = {
             "taluy/cameras/cam_front": {
-                8: "red_buoy",
-                4: "gate_red_arrow",
-                3: "gate_blue_arrow",
-                5: "gate_middle_part",
-                12: "torpedo_map",
-                14: "octagon",
+                8: "red_buoy_link",
+                4: "gate_red_arrow_link",
+                3: "gate_blue_arrow_link",
+                5: "gate_middle_part_link",
+                12: "torpedo_map_link",
+                14: "octagon_link",
             },
             "taluy/cameras/cam_bottom": {9: "bin/whole", 10: "bin/red", 11: "bin/blue"},
         }
@@ -329,15 +329,6 @@ class CameraDetectionNode:
 
             offset_x = math.tan(angles[0]) * distance * 1.0
             offset_y = math.tan(angles[1]) * distance * 1.0
-
-            # Create point message
-            point_msg = PointStamped()
-            point_msg.header.frame_id = camera_frame
-            point_msg.header.stamp = rospy.Time.now()
-            point_msg.point.x = offset_x
-            point_msg.point.y = offset_y
-            point_msg.point.z = distance
-
             # # Publish point message
             # if detection_id in self.detection_pubs:
             #     self.detection_pubs[detection_id].publish(point_msg)

--- a/auv_vision/auv_detection/scripts/camera_detection_pose_estimator.py
+++ b/auv_vision/auv_detection/scripts/camera_detection_pose_estimator.py
@@ -118,18 +118,18 @@ class CameraDetectionNode:
         self.object_transform_pub = rospy.Publisher(
             "object_transform_updates", TransformStamped, queue_size=10
         )
-
+        # Initialize tf2 buffer and listener for transformations
+        self.tf_buffer = tf2_ros.Buffer()
+        self.tf_listener = tf2_ros.TransformListener(self.tf_buffer)
         self.camera_calibrations = {
-            "taluy/cameras/cam_front": CameraCalibration("taluy/cameras/cam_front"),
-            "taluy/cameras/cam_bottom": CameraCalibration("taluy/cameras/cam_bottom"),
+            "taluy/cameras/cam_front": CameraCalibration("cameras/cam_front"),
+            "taluy/cameras/cam_bottom": CameraCalibration("cameras/cam_bottom"),
         }
-
+        rospy.Subscriber("/yolo_result", YoloResult, self.detection_callback)
         self.camera_frames = {
             "taluy/cameras/cam_front": "taluy/base_link/front_camera_optical_link",
             "taluy/cameras/cam_bottom": "taluy/base_link/bottom_camera_optical_link",
         }
-        rospy.Subscriber("/yolo_result", YoloResult, self.detection_callback)
-
         self.props = {
             "red_buoy_link": BuoyRed(),
             "gate_red_arrow_link": GateRedArrow(),
@@ -151,16 +151,13 @@ class CameraDetectionNode:
             "taluy/cameras/cam_bottom": {9: "bin/whole", 10: "bin/red", 11: "bin/blue"},
         }
 
-        # Initialize tf2 buffer and listener for transformations
-        self.tf_buffer = tf2_ros.Buffer()
-        self.tf_listener = tf2_ros.TransformListener(self.tf_buffer)
 
         # Publishers for detected object coordinates
         # Publisher for detected object transforms
 
         # Subscribe to YOLO detections and altitude
         self.altitude = None
-        #rospy.Subscriber("dvl/altitude", Float32, self.altitude_callback)
+        rospy.Subscriber("dvl/altitude", Float32, self.altitude_callback)
 
     def altitude_callback(self, msg: Float32):
         self.altitude = msg.data
@@ -288,7 +285,6 @@ class CameraDetectionNode:
 
     def detection_callback(self, detection_msg: YoloResult):
         camera_ns = "taluy/cameras/cam_front"
-
         calibration = self.camera_calibrations[camera_ns]
         camera_frame = self.camera_frames[camera_ns]
 

--- a/auv_vision/auv_detection/scripts/camera_detection_pose_estimator.py
+++ b/auv_vision/auv_detection/scripts/camera_detection_pose_estimator.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+
+import rospy
+import math
+from geometry_msgs.msg import PointStamped, PoseArray, PoseStamped, Pose, TransformStamped, Transform, Vector3, Quaternion
+from ultralytics_ros.msg import YoloResult
+from sensor_msgs.msg import Range
+from std_msgs.msg import Float32
+import auv_common_lib.vision.camera_calibrations as camera_calibrations
+import tf2_ros
+import tf2_geometry_msgs
+
+
+class CameraCalibration:
+    def __init__(self, namespace: str):
+        self.calibration = camera_calibrations.CameraCalibrationFetcher(
+            namespace, True
+        ).get_camera_info()
+
+    def calculate_angles(self, pixel_coordinates: tuple) -> tuple:
+        fx = self.calibration.K[0]
+        fy = self.calibration.K[4]
+        cx = self.calibration.K[2]
+        cy = self.calibration.K[5]
+        norm_x = (pixel_coordinates[0] - cx) / fx
+        norm_y = (pixel_coordinates[1] - cy) / fy
+        angle_x = math.atan(norm_x)
+        angle_y = math.atan(norm_y)
+        return angle_x, angle_y
+
+    def distance_from_height(self, real_height: float, measured_height: float) -> float:
+        focal_length = self.calibration.K[4]
+        distance = (real_height * focal_length) / measured_height
+        return distance
+
+    def distance_from_width(self, real_width: float, measured_width: float) -> float:
+        focal_length = self.calibration.K[0]
+        distance = (real_width * focal_length) / measured_width
+        return distance
+
+
+class Prop:
+    def __init__(self, id: int, name: str, real_height: float, real_width: float):
+        self.id = id
+        self.name = name
+        self.real_height = real_height
+        self.real_width = real_width
+
+    def estimate_distance(
+        self,
+        measured_height: float,
+        measured_width: float,
+        calibration: CameraCalibration,
+    ):
+        distance_from_height = None
+        distance_from_width = None
+
+        if self.real_height is not None:
+            distance_from_height = calibration.distance_from_height(
+                self.real_height, measured_height
+            )
+
+        if self.real_width is not None:
+            distance_from_width = calibration.distance_from_width(
+                self.real_width, measured_width
+            )
+
+        if distance_from_height is not None and distance_from_width is not None:
+            return (distance_from_height + distance_from_width) * 0.5
+        elif distance_from_height is not None:
+            return distance_from_height
+        elif distance_from_width is not None:
+            return distance_from_width
+        else:
+            rospy.logerr(f"Could not estimate distance for prop {self.name}")
+            return None
+
+
+class GateRedArrow(Prop):
+    def __init__(self):
+        super().__init__(4, "gate_red_arrow", 0.3048, 0.3048)
+
+
+class GateBlueArrow(Prop):
+    def __init__(self):
+        super().__init__(3, "gate_blue_arrow", 0.3048, 0.3048)
+
+
+class GateMiddlePart(Prop):
+    def __init__(self):
+        super().__init__(5, "gate_middle_part", 0.6096, None)
+
+
+class BuoyRed(Prop):
+    def __init__(self):
+        super().__init__(8, "red_buoy", 0.292, 0.203)
+
+
+class TorpedoMap(Prop):
+    def __init__(self):
+        super().__init__(12, "torpedo_map", 0.6096, 0.6096)
+
+
+class BinWhole(Prop):
+    def __init__(self):
+        super().__init__(9, "bin_whole", None, None)
+
+
+class Octagon(Prop):
+    def __init__(self):
+        super().__init__(14, "octagon", 0.92, 1.30)
+
+
+class CameraDetectionNode:
+    def __init__(self):
+        rospy.init_node("camera_detection_node", anonymous=True)
+        rospy.loginfo("Camera detection node started")
+        self.camera_calibrations = {
+            "taluy/cameras/cam_front": CameraCalibration("taluy/cameras/cam_front"),
+            "taluy/cameras/cam_bottom": CameraCalibration("taluy/cameras/cam_bottom"),
+        }
+
+        self.camera_frames = {
+            "taluy/cameras/cam_front": "taluy/base_link/front_camera_optical_link",
+            "taluy/cameras/cam_bottom": "taluy/base_link/bottom_camera_optical_link",
+        }
+
+        self.props = {
+            "red_buoy": BuoyRed(),
+            "gate_red_arrow": GateRedArrow(),
+            "gate_blue_arrow": GateBlueArrow(),
+            "gate_middle_part": GateMiddlePart(),
+            "torpedo_map": TorpedoMap(),
+            "octagon": Octagon(),
+        }
+
+        self.id_tf_map = {
+            "taluy/cameras/cam_front": {
+                8: "red_buoy",
+                4: "gate_red_arrow",
+                3: "gate_blue_arrow",
+                5: "gate_middle_part",
+                12: "torpedo_map",
+                14: "octagon",
+            },
+            "taluy/cameras/cam_bottom": {9: "bin/whole", 10: "bin/red", 11: "bin/blue"},
+        }
+
+        # Initialize tf2 buffer and listener for transformations
+        self.tf_buffer = tf2_ros.Buffer()
+        self.tf_listener = tf2_ros.TransformListener(self.tf_buffer)
+
+        # Publishers for detected object coordinates
+        # Publisher for detected object transforms
+        self.object_transform_pub = rospy.Publisher(
+            "/taluy/map/object_transform_updates", TransformStamped, queue_size=10
+        )
+
+        # Subscribe to YOLO detections and altitude
+        self.altitude = None
+        rospy.Subscriber("/taluy/sensors/dvl/altitude", Float32, self.altitude_callback)
+        rospy.Subscriber("/yolo_result", YoloResult, self.detection_callback)
+
+    def altitude_callback(self, msg: Float32):
+        self.altitude = msg.data
+
+    def calculate_intersection_with_ground(self, point1_odom, point2_odom):
+        # Calculate t where the z component is zero (ground plane)
+        if point2_odom.point.z != point1_odom.point.z:
+            t = -point1_odom.point.z / (point2_odom.point.z - point1_odom.point.z)
+
+            # Check if t is within the segment range [0, 1]
+            if 0 <= t <= 1:
+                # Calculate intersection point
+                x = point1_odom.point.x + t * (
+                    point2_odom.point.x - point1_odom.point.x
+                )
+                y = point1_odom.point.y + t * (
+                    point2_odom.point.y - point1_odom.point.y
+                )
+                z = 0  # ground plane
+                return x, y, z
+            else:
+                rospy.logwarn("No intersection with ground plane within the segment.")
+                return None
+        else:
+            rospy.logwarn("The line segment is parallel to the ground plane.")
+            return None
+
+    def process_altitude_projection(self, detection, camera_ns: str):
+        if self.altitude is None:
+            rospy.logwarn("No altitude data available")
+            return
+
+        detection_id = detection.results[0].id
+        if detection_id != 9:
+            return
+
+        bbox_bottom_x = detection.bbox.center.x
+        bbox_bottom_y = detection.bbox.center.y + detection.bbox.size_y * 0.5
+
+        angles = self.camera_calibrations[camera_ns].calculate_angles(
+            (bbox_bottom_x, bbox_bottom_y)
+        )
+
+        distance = 500.0
+
+        offset_x = math.tan(angles[0]) * distance * 1.0
+        offset_y = math.tan(angles[1]) * distance * 1.0
+
+        # optical_camera_frame'de tanımlı iki nokta
+        point1 = PointStamped()
+        point1.header.frame_id = self.camera_frames[camera_ns]
+        point1.point.x = 0
+        point1.point.y = 0
+        point1.point.z = 0
+
+        point2 = PointStamped()
+        point2.header.frame_id = self.camera_frames[camera_ns]
+        point2.point.x = offset_x
+        point2.point.y = offset_y
+        point2.point.z = distance
+
+        try:
+            transform = self.tf_buffer.lookup_transform(
+                "odom",
+                self.camera_frames[camera_ns],
+                rospy.Time(0),
+                rospy.Duration(1.0),
+            )
+            point1_odom = tf2_geometry_msgs.do_transform_point(point1, transform)
+            point2_odom = tf2_geometry_msgs.do_transform_point(point2, transform)
+
+            point1_odom.point.z += self.altitude + 0.18
+            point2_odom.point.z += self.altitude + 0.18
+
+            # Zemin ile kesişim noktasını bul
+            intersection = self.calculate_intersection_with_ground(
+                point1_odom, point2_odom
+            )
+            if intersection:
+                x, y, z = intersection
+                point_msg = PointStamped()
+                point_msg.header.frame_id = "odom"
+                point_msg.header.stamp = rospy.Time.now()
+                point_msg.point.x = x
+                point_msg.point.y = y
+                point_msg.point.z = z
+
+                # if detection_id in self.detection_pubs:
+                #     self.detection_pubs[detection_id].publish(point_msg)
+
+                transform_stamped_msg = TransformStamped()
+                transform_stamped_msg.header.stamp = rospy.Time.now()
+                transform_stamped_msg.header.frame_id = "odom"
+                transform_stamped_msg.child_frame_id = self.id_tf_map[camera_ns][detection_id]
+
+                transform_stamped_msg.transform.translation = Vector3(x, y, z)
+                transform_stamped_msg.transform.rotation = Quaternion(0, 0, 0, 1)
+                self.object_transform_pub.publish(transform_stamped_msg)
+
+        except (
+            tf2_ros.LookupException,
+            tf2_ros.ConnectivityException,
+            tf2_ros.ExtrapolationException,
+        ) as e:
+            rospy.logerr(f"Transform error: {e}")
+
+    def check_if_detection_is_inside_image(
+        self, detection, image_width: int = 640, image_height: int = 480
+    ) -> bool:
+        center = detection.bbox.center
+        half_size_x = detection.bbox.size_x * 0.5
+        half_size_y = detection.bbox.size_y * 0.5
+        deadzone = 5  # pixels
+        if (
+            center.x + half_size_x >= image_width - deadzone
+            or center.x - half_size_x <= deadzone
+        ):
+            return False
+        if (
+            center.y + half_size_y >= image_height - deadzone
+            or center.y - half_size_y <= deadzone
+        ):
+            return False
+        return True
+
+    def detection_callback(self, detection_msg: YoloResult):
+        camera_ns = "taluy/cameras/cam_front"
+
+        calibration = self.camera_calibrations[camera_ns]
+        camera_frame = self.camera_frames[camera_ns]
+
+        for detection in detection_msg.detections.detections:
+            if len(detection.results) == 0:
+                continue
+
+            detection_id = detection.results[0].id
+            if detection_id not in self.id_tf_map[camera_ns]:
+                continue
+
+            # Eğer detection bin_whole ise (id=9), altitude projection kullan
+            if detection_id == 9:
+                self.process_altitude_projection(detection, camera_ns)
+                continue
+
+            prop_name = self.id_tf_map[camera_ns][detection_id]
+            if prop_name not in self.props:
+                continue
+
+            prop = self.props[prop_name]
+            if self.check_if_detection_is_inside_image(detection) == False:
+                continue
+
+            # Calculate distance using object dimensions
+            distance = prop.estimate_distance(
+                detection.bbox.size_y,
+                detection.bbox.size_x,
+                self.camera_calibrations[camera_ns],
+            )
+
+            if distance is None:
+                continue
+
+            # Calculate angles from pixel coordinates
+            angles = self.camera_calibrations[camera_ns].calculate_angles(
+                (detection.bbox.center.x, detection.bbox.center.y)
+            )
+
+            offset_x = math.tan(angles[0]) * distance * 1.0
+            offset_y = math.tan(angles[1]) * distance * 1.0
+
+            # Create point message
+            point_msg = PointStamped()
+            point_msg.header.frame_id = camera_frame
+            point_msg.header.stamp = rospy.Time.now()
+            point_msg.point.x = offset_x
+            point_msg.point.y = offset_y
+            point_msg.point.z = distance
+
+            # # Publish point message
+            # if detection_id in self.detection_pubs:
+            #     self.detection_pubs[detection_id].publish(point_msg)
+            transform_stamped_msg = TransformStamped()
+            transform_stamped_msg.header.stamp = rospy.Time.now()
+            transform_stamped_msg.header.frame_id = camera_frame
+            transform_stamped_msg.child_frame_id = prop_name
+
+            transform_stamped_msg.transform.translation = Vector3(offset_x, offset_y, distance)
+            transform_stamped_msg.transform.rotation = Quaternion(0, 0, 0, 1)
+
+            self.object_transform_pub.publish(transform_stamped_msg)
+
+
+    def run(self):
+        rospy.spin()
+
+
+if __name__ == "__main__":
+    try:
+        node = CameraDetectionNode()
+        node.run()
+    except rospy.ROSInterruptException:
+        pass

--- a/auv_vision/auv_detection/scripts/camera_detection_pose_estimator.py
+++ b/auv_vision/auv_detection/scripts/camera_detection_pose_estimator.py
@@ -113,8 +113,12 @@ class Octagon(Prop):
 
 class CameraDetectionNode:
     def __init__(self):
-        rospy.init_node("camera_detection_node", anonymous=True)
+        rospy.init_node("camera_detection_pose_estimator", anonymous=True)
         rospy.loginfo("Camera detection node started")
+        self.object_transform_pub = rospy.Publisher(
+            "object_transform_updates", TransformStamped, queue_size=10
+        )
+
         self.camera_calibrations = {
             "taluy/cameras/cam_front": CameraCalibration("taluy/cameras/cam_front"),
             "taluy/cameras/cam_bottom": CameraCalibration("taluy/cameras/cam_bottom"),
@@ -124,6 +128,7 @@ class CameraDetectionNode:
             "taluy/cameras/cam_front": "taluy/base_link/front_camera_optical_link",
             "taluy/cameras/cam_bottom": "taluy/base_link/bottom_camera_optical_link",
         }
+        rospy.Subscriber("/yolo_result", YoloResult, self.detection_callback)
 
         self.props = {
             "red_buoy_link": BuoyRed(),
@@ -152,14 +157,10 @@ class CameraDetectionNode:
 
         # Publishers for detected object coordinates
         # Publisher for detected object transforms
-        self.object_transform_pub = rospy.Publisher(
-            "/taluy/map/object_transform_updates", TransformStamped, queue_size=10
-        )
 
         # Subscribe to YOLO detections and altitude
         self.altitude = None
-        rospy.Subscriber("/taluy/sensors/dvl/altitude", Float32, self.altitude_callback)
-        rospy.Subscriber("/yolo_result", YoloResult, self.detection_callback)
+        #rospy.Subscriber("dvl/altitude", Float32, self.altitude_callback)
 
     def altitude_callback(self, msg: Float32):
         self.altitude = msg.data


### PR DESCRIPTION
Added a new `camera_detection_pose_estimation` node to the Kalman Fliter backed mapping node, which processes bounding boxes detected by YOLO to generate object poses and publishes them as a single transformstampedtopic.

This implementation was tested in the **pool**  and showed relatively good performance.

Additionally, `clear_object_transforms` has been  integrated into the SMACH framework. However, we observed that the frames generated by the Kalman Filter currently have their Z-axis inverted. This issue will be addressed and corrected as soon as possible.