### PR TITLE
Parameter to not start the autonomous system at simulation launch

### DIFF
--- a/auv_sim/auv_sim_bringup/launch/inc/start_bridge.launch
+++ b/auv_sim/auv_sim_bringup/launch/inc/start_bridge.launch
@@ -2,7 +2,7 @@
 <launch>
   <arg name="namespace" default="taluy" />
   <arg name="control_rate" default="20" />
-  <arg name="use_gui" default="false" />
+  <arg name="use_gui" default="true" />
 
   <rosparam command="load" file="$(find auv_sim_description)/config/environment.yaml" />
 

--- a/auv_sim/auv_sim_bringup/launch/start_gazebo.launch
+++ b/auv_sim/auv_sim_bringup/launch/start_gazebo.launch
@@ -16,6 +16,7 @@
     <arg name="pressure_update_rate" default="20" />
     <arg name="enable_logging" default="false" />
     <arg name="logging_directory" default="$(optenv HOME)/bags" />
+    <arg name="start_bridge" default="true" />
 
 
     <!-- Run RViz -->
@@ -62,11 +63,13 @@
     </include>
 
     <!-- Start bridge -->
-    <include file="$(find auv_sim_bringup)/launch/inc/start_bridge.launch">
-        <arg name="namespace" value="$(arg namespace)" />
-        <arg name="control_rate" value="$(arg control_rate)" />
-        <arg name="use_gui" value="$(arg use_gui)" />
-    </include>
+    <group if="$(arg start_bridge)">
+        <include file="$(find auv_sim_bringup)/launch/inc/start_bridge.launch">
+            <arg name="namespace" value="$(arg namespace)" />
+            <arg name="control_rate" value="$(arg control_rate)" />
+            <arg name="use_gui" value="$(arg use_gui)" />
+        </include>
+    </group>
 
     <group if="$(arg enable_logging)">
         <include file="$(find auv_bringup)/launch/inc/logging.launch.xml">


### PR DESCRIPTION
**New parameter:** `start_bridge` (default: `true`).  
If you plan to launch the autonomous system from a separate terminal, set `start_bridge: false` and run:

```bash
roslaunch auv_sim_bringup start_bridge.launch
```
No need to restart the simulation and RViz — and re-add all those messages (Hey @frk781)  — just because you fixed a typo!

Kudos to @frk781 for the idea