### PR TITLE
fix ci: bump industrial-ci host version to ubuntu-latest

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         # host: [ubuntu-20.04, self-hosted]
-        host: [ubuntu-20.04]
+        host: [ubuntu-latest]
     uses: ./.github/workflows/industrial_ci.yml
     with:
       runner: ${{ matrix.host }}


### PR DESCRIPTION
Bumping the industrial-ci host image version to ubuntu-latest fixes our ci issue, we can do this because ros runs in a docker container in this host image, which uses ubuntu 20.04