### PR TITLE
fix follow path client

### DIFF
--- a/auv_navigation/auv_navigation/src/auv_navigation/follow_path_action/follow_path_client.py
+++ b/auv_navigation/auv_navigation/src/auv_navigation/follow_path_action/follow_path_client.py
@@ -34,10 +34,7 @@ class FollowPathActionClient:
             result = self.client.get_result()
 
             if result and result.success:
-                rospy.logdebug(
-                    "[follow_path client] Task succeeded: execution time: %.2f seconds",
-                    result.execution_time,
-                )
+                rospy.logdebug("[follow_path client] Task succeeded")
                 return True
             else:
                 rospy.logwarn("[follow_path client] Task failed")


### PR DESCRIPTION
`execution_time` is not an existing value in the FollowPath action msg, I am guessing this was a thing in the early design and removed later on, and was forgotten here.

removing reference to that non-existing value was removed, so the issue was fixed

`FollowPath.action:`
```
# Goal
nav_msgs/Path[] paths

---
# Result
bool success

---
# Feedback
float32 current_segment_progress
float32 overall_progress
uint8 current_segment_index
```