### PR TITLE
Fix yaw frame handling

### DIFF
--- a/auv_control/auv_control/include/auv_control/controller_ros.h
+++ b/auv_control/auv_control/include/auv_control/controller_ros.h
@@ -209,11 +209,17 @@ class ControllerROS {
             tf_buffer.lookupTransform(depth_control_reference_frame_,
                                       source_frame.value(), ros::Time::now());
 
-        // only transform the z-axis component of the pose
-        geometry_msgs::Point transformed_z;
-        tf2::doTransform(msg->pose.position, transformed_z, transform_stamped);
-        transformed_pose.position.z =
-            transformed_z.z;  // override the z component
+        // Transform orientation and the z-axis position component
+        geometry_msgs::PoseStamped in_pose;
+        in_pose.header.frame_id = source_frame.value();
+        in_pose.header.stamp = ros::Time::now();
+        in_pose.pose = msg->pose;
+
+        geometry_msgs::PoseStamped out_pose;
+        tf2::doTransform(in_pose, out_pose, transform_stamped);
+
+        transformed_pose.position.z = out_pose.pose.position.z;
+        transformed_pose.orientation = out_pose.pose.orientation;
 
       } catch (tf2::TransformException& ex) {  // If unsuccessful, exit and
                                                // don't update desired state


### PR DESCRIPTION
## Summary
- transform orientation along with z position in cmd_pose callback

## Testing
- `clang-format -i auv_control/auv_control/include/auv_control/controller_ros.h`
- `catkin_make run_tests` *(fails: command not found)*
- `colcon test --packages-select auv_controllers` *(fails: command not found)*
- `pip install pre-commit --user` *(fails: Could not find a version)*

------
https://chatgpt.com/codex/tasks/task_e_684007caa2b8832798502e4dc879926c