### PR TITLE
Fix the pressure_odom error

### DIFF
--- a/auv_navigation/auv_localization/scripts/pressure_odometry_node.py
+++ b/auv_navigation/auv_localization/scripts/pressure_odometry_node.py
@@ -90,7 +90,6 @@ class PressureToOdom:
         orientation = self.imu_data.orientation
         quat = [orientation.x, orientation.y, orientation.z, orientation.w]
         rotation_matrix = tf.transformations.quaternion_matrix(quat)[:3, :3]
-        # now a flat vector, dot works
         rotated_vector = rotation_matrix.dot(self.base_to_pressure_translation)
         return float(rotated_vector[2])
 

--- a/auv_navigation/auv_localization/scripts/pressure_odometry_node.py
+++ b/auv_navigation/auv_localization/scripts/pressure_odometry_node.py
@@ -73,7 +73,11 @@ class PressureToOdom:
                 arr = np.array(trans)
                 # flatten any nested structure to 1D [x, y, z]
                 self.base_to_pressure_translation = arr.flatten()
-            except Exception as e:
+            except (
+                tf.LookupException,
+                tf.ConnectivityException,
+                tf.ExtrapolationException,
+            ) as e:
                 rospy.logwarn_throttle(
                     10, f"Pressure TF not available: {e}; using zero offset."
                 )


### PR DESCRIPTION
Cache the sensor transform on first lookup and return zero offset if unavailable, preventing callback blocking; once retrieved, use its Z-offset (rotated by IMU orientation when ready) in depth estimates.

Related error:

```
[ERROR] [1750941137.856573, 2.552000]: bad callback: <bound method PressureToOdom.depth_callback of <__main__.PressureToOdom object at 0x7f0d149c52e0>>
Traceback (most recent call last):
  File "/opt/ros/noetic/lib/python3/dist-packages/rospy/topics.py", line 750, in _invoke_callback
    cb(msg)
  File "/home/ozan/catkin_ws/src/auv-software/auv_navigation/auv_localization/scripts/pressure_odometry_node.py", line 108, in depth_callback
    base_depth = calibrated_depth + self.get_base_to_pressure_height()
  File "/home/ozan/catkin_ws/src/auv-software/auv_navigation/auv_localization/scripts/pressure_odometry_node.py", line 76, in get_base_to_pressure_height
    assert self.base_to_pressure_translation is not None
AssertionError
```
