### PR TITLE
Quick changes to our behaviour tree

### DIFF
--- a/auv_smach/src/auv_smach/initialize.py
+++ b/auv_smach/src/auv_smach/initialize.py
@@ -13,6 +13,7 @@ from auv_smach.common import (
 )
 from typing import Optional, Literal
 from dataclasses import dataclass
+from auv_smach.common import SetDetectionFocusState
 
 
 class ResetOdometryState(smach_ros.ServiceState):
@@ -153,6 +154,15 @@ class InitializeState(smach.State):
             smach.StateMachine.add(
                 "ODOMETRY_ENABLE",
                 OdometryEnableState(),
+                transitions={
+                    "succeeded": "SET_DETECTION_TO_NONE",
+                    "preempted": "preempted",
+                    "aborted": "aborted",
+                },
+            )
+            smach.StateMachine.add(
+                "SET_DETECTION_TO_NONE",
+                SetDetectionFocusState(focus_object="none"),
                 transitions={
                     "succeeded": "CLEAR_OBJECT_MAP",
                     "preempted": "preempted",

--- a/auv_smach/src/auv_smach/slalom.py
+++ b/auv_smach/src/auv_smach/slalom.py
@@ -157,7 +157,7 @@ class NavigateThroughSlalomState(smach.State):
                     cancel_on_success=False,
                     keep_orientation=False,
                     max_linear_velocity=0.1,
-                    max_angular_velocity=0.15,
+                    max_angular_velocity=0.1,
                 ),
                 transitions={
                     "succeeded": "LOOK_RIGHT",
@@ -178,10 +178,10 @@ class NavigateThroughSlalomState(smach.State):
                     cancel_on_success=False,
                     keep_orientation=False,
                     max_linear_velocity=0.1,
-                    max_angular_velocity=0.15,
+                    max_angular_velocity=0.1,
                 ),
                 transitions={
-                    "succeeded": "LOCK_ON_WAYPOINT_1",
+                    "succeeded": "LOCK_ON_RED_PIPE",
                     "preempted": "preempted",
                     "aborted": "CANCEL_ALIGN_CONTROLLER",
                 },


### PR DESCRIPTION
1. Set detection focus to none before clearing the map at init
Critical for coin flip, roll, etc.

2. Fix the consistency error in slalom smach

3. Slalom selam state's yaw velocity is now 2/3 of the older one.