### PR TITLE
[fix] [improvement] Check the existence of a transform and use fresh transform in AFC

### DIFF
--- a/auv_control/auv_control/include/auv_control/controller_ros.h
+++ b/auv_control/auv_control/include/auv_control/controller_ros.h
@@ -121,21 +121,22 @@ class ControllerROS {
   }
 
   void spin() {
+    const auto dt = 1.0 / rate_.expectedCycleTime().toSec();
+
     while (ros::ok()) {
       ros::spinOnce();
       rate_.sleep();
 
-      if (!controller_ || dt_ == 0.0) {  // If controller is not loaded or dt_
-                                         // is zero, skip control
+      if (!controller_) {
         continue;
       }
 
       const auto control_output =
-          controller_->control(state_, desired_state_, d_state_, dt_);
+          controller_->control(state_, desired_state_, d_state_, dt);
 
       geometry_msgs::WrenchStamped wrench_msg;
       if (is_control_enabled() && !is_timeouted()) {
-        wrench_msg.header.stamp = last_odom_stamp_;
+        wrench_msg.header.stamp = ros::Time::now();
         wrench_msg.header.frame_id = body_frame_;
         wrench_msg.wrench =
             auv::common::conversions::convert<ControllerBase::WrenchVector,
@@ -158,10 +159,6 @@ class ControllerROS {
   }
 
   void odometry_callback(const nav_msgs::Odometry::ConstPtr& msg) {
-    if (!last_odom_stamp_.is_zero()) {
-      dt_ = (msg->header.stamp - last_odom_stamp_).toSec();
-    }
-    last_odom_stamp_ = msg->header.stamp;
     state_ =
         auv::common::conversions::convert<nav_msgs::Odometry,
                                           ControllerBase::StateVector>(*msg);
@@ -373,8 +370,6 @@ class ControllerROS {
   ControlEnableSub control_enable_sub_;
   ControllerBasePtr controller_;
   ros::Time latest_command_time_{ros::Time(0)};
-  ros::Time last_odom_stamp_{ros::Time(0)};
-  double dt_{0.0};
 
   ControllerBase::StateVector state_{ControllerBase::StateVector::Zero()};
   ControllerBase::StateVector desired_state_{


### PR DESCRIPTION
What is new?
1. If an alignment is requested, check if the transform exists. If not, don't accept.
    We used to accept any requests. 

2. in get_error, use fresh timestamps instead of using the last transform. In case transform was there and now not, send zero twist and disable controller.



The code certainly works now, no crashing :) @ozanhakantunca 