### PR TITLE
[camera_pose change]: fix overloading in camera node

### DIFF
--- a/auv_vision/auv_detection/scripts/camera_detection_pose_estimator.py
+++ b/auv_vision/auv_detection/scripts/camera_detection_pose_estimator.py
@@ -182,11 +182,13 @@ class CameraDetectionNode:
             "/yolo_result",
             YoloResult,
             lambda msg: self.detection_callback(msg, camera_source="front_camera"),
+            queue_size=1,
         )
         rospy.Subscriber(
             "/yolo_result_2",
             YoloResult,
             lambda msg: self.detection_callback(msg, camera_source="bottom_camera"),
+            queue_size=1,
         )
         self.frame_id_to_camera_ns = {
             "taluy/base_link/bottom_camera_link": "taluy/cameras/cam_bottom",
@@ -572,6 +574,20 @@ class CameraDetectionNode:
             return  # Stop processing if the source is unknown
 
         camera_frame = self.camera_frames[camera_ns]
+        try:
+            camera_to_odom_transform = self.tf_buffer.lookup_transform(
+                camera_frame,
+                "odom",
+                detection_msg.header.stamp,
+                rospy.Duration(1.0),
+            )
+        except (
+            tf2_ros.LookupException,
+            tf2_ros.ConnectivityException,
+            tf2_ros.ExtrapolationException,
+        ) as e:
+            rospy.logwarn_throttle(15, f"Transform error: {e}")
+            return
 
         # Search for torpedo map
         torpedo_map_bbox = None
@@ -666,20 +682,6 @@ class CameraDetectionNode:
             props_yaw_msg.object = prop.name
             props_yaw_msg.angle = -angles[0]
             self.props_yaw_pub.publish(props_yaw_msg)
-            try:
-                camera_to_odom_transform = self.tf_buffer.lookup_transform(
-                    camera_frame,
-                    "odom",
-                    detection_msg.header.stamp,
-                    rospy.Duration(1.0),
-                )
-            except (
-                tf2_ros.LookupException,
-                tf2_ros.ConnectivityException,
-                tf2_ros.ExtrapolationException,
-            ) as e:
-                rospy.logerr(f"Transform error: {e}")
-                return
 
             offset_x = math.tan(angles[0]) * distance * 1.0
             offset_y = math.tan(angles[1]) * distance * 1.0


### PR DESCRIPTION
1. Yolo message's now get processed with queue size 1: This ensures that the callback always processes the most recent message, and the messages dont get piled up. If new data arrives before the old data is processed, the old message is dropped. This both frees resource, and we won't get these spams:

```
Transform error: Lookup would require extrapolation 23.204000000s into the past.  Requested time 325.047000000 but the earliest data is at time 348.251000000, when looking up transform from frame [odom] to frame [taluy/base_link/front_camera_optical_link]
[ERROR] [1754872033.605755, 350.985000]: Transform error: Lookup would require extrapolation 23.066000000s into t
```
So this PR solves #109. We can start the detection node before the localization node with our minds in peace, and our terminals clean.
2. The transform lookup moved to the beginning of the detection_callback function to exit quickly if no transform. So we avoid processing 1000 useless bbox's

