### PR TITLE
fix bags

### DIFF
--- a/auv_bringup/launch/inc/logging.launch.xml
+++ b/auv_bringup/launch/inc/logging.launch.xml
@@ -4,7 +4,7 @@
   <arg name="prefix" default="log"/>
   <arg name="logging_directory" default="$(optenv PWD)"/>
   <arg name="include_pattern" default=".*"/>
-  <arg name="exclude_pattern" default="/.*image_[^/]*$|/.*theora$|/(?!.*image_raw/compressed$).*compressed$|/.*compressedDepth$|/points_filtered$|/points$"/>
+  <arg name="exclude_pattern" default="/.*image_[^/]*$|/.*theora$|/(?!.*image_raw/compressed$).*compressed$|/.*compressedDepth$|/.*points_filtered$|/.*points$"/>
   <arg name="topics" default=""/>
   <group ns="$(arg namespace)">
     <node


### PR DESCRIPTION
- exclude `image_corrected`
- remove hardcoded topic name in the pattern

we should probably create the compressed version of `image_corrected` topic.

we also should follow the `x/image_raw` and `x/image_raw/compressed` naming conventions for image topics to avoid similar huge bag issues in the future