### PR TITLE
fix logging

### DIFF
--- a/auv_bringup/launch/logging.launch
+++ b/auv_bringup/launch/logging.launch
@@ -4,7 +4,7 @@
   <arg name="prefix" default="log"/>
   <arg name="logging_directory" default="$(optenv HOME)/bags"/>
   <arg name="include_pattern" default=".*"/>
-  <arg name="exclude_pattern" default="/.*image_[^/]*$|/.*theora$|/(?!.*image_raw/compressed$).*compressed$|/.*compressedDepth$|/.*points_filtered$|/.*points$"/>
+  <arg name="exclude_pattern" default="/(?!.*(?:image_rect_color/compressed$|yolo_[^/]+/image_raw/compressed$|camera/color/image_raw/compressed$|camera/depth/image_rect_raw/compressed$)).*(?:image|compressed)|/.*(?:points_filtered|points|cloud|mask)$"/>
   <arg name="topics" default=""/>
   <arg name="log_filename" default=""/>
   <group ns="$(arg namespace)">

--- a/auv_bringup/launch/logging.launch
+++ b/auv_bringup/launch/logging.launch
@@ -4,7 +4,7 @@
   <arg name="prefix" default="log"/>
   <arg name="logging_directory" default="$(optenv HOME)/bags"/>
   <arg name="include_pattern" default=".*"/>
-  <arg name="exclude_pattern" default="/(?!.*(?:image_rect_color/compressed$|yolo_[^/]+/image_raw/compressed$|camera/color/image_raw/compressed$|camera/depth/image_rect_raw/compressed$)).*(?:image|compressed)|/.*(?:points_filtered|points|cloud|mask)$"/>
+  <arg name="exclude_pattern" default="^/(?!.*(?:image_rect_color/compressed|yolo_[^/]+/image_raw/compressed|camera/color/image_raw/compressed|camera/depth/image_rect_raw/compressed)$).*(?:image|compressed).*$|^/.*(?:points_filtered|points|cloud|mask)$"/>
   <arg name="topics" default=""/>
   <arg name="log_filename" default=""/>
   <group ns="$(arg namespace)">

--- a/auv_bringup/launch/start.launch
+++ b/auv_bringup/launch/start.launch
@@ -9,7 +9,7 @@
   <arg name="enable_dvl" default="$(eval arg('namespace') == 'taluy')" />
   <arg name="enable_vectornav" default="$(eval arg('namespace') == 'taluy_mini')" />
   <arg name="use_gui" default="false" />
-  <arg name="enable_logging" default="false" />
+  <arg name="enable_logging" default="true" />
   <arg name="logging_directory" default="$(optenv HOME)/bags" />
   <arg name="log_filename" default="" />
 

--- a/auv_vision/auv_detection/launch/inc/tracker_bottom.launch
+++ b/auv_vision/auv_detection/launch/inc/tracker_bottom.launch
@@ -8,7 +8,7 @@
   <arg name="ultralytics_models_dir" default="$(find ultralytics_ros)/models"/>
   <arg name="input_topic" default="/$(arg namespace)/cameras/cam_bottom/image_rect_color"/>
   <arg name="result_topic" default="/yolo_result_bottom"/>
-  <arg name="result_image_topic" default="/yolo_image_bottom"/>
+  <arg name="result_image_topic" default="/yolo_bottom/image_raw/compressed"/>
   <arg name="conf_thres" default="0.25"/>
   <arg name="iou_thres" default="0.45"/>
   <arg name="max_det" default="300"/>

--- a/auv_vision/auv_detection/launch/inc/tracker_detection.launch
+++ b/auv_vision/auv_detection/launch/inc/tracker_detection.launch
@@ -8,7 +8,7 @@
   <arg name="ultralytics_models_dir" default="$(find ultralytics_ros)/models"/>
   <arg name="input_topic" default="/$(arg namespace)/cameras/cam_bottom/image_rect_color"/>
   <arg name="result_topic" default="/yolo_result_shape_detection"/>
-  <arg name="result_image_topic" default="/yolo_image_shape_detection"/>
+  <arg name="result_image_topic" default="/yolo_shape_detection/image_raw/compressed"/>
   <arg name="conf_thres" default="0.25"/>
   <arg name="iou_thres" default="0.45"/>
   <arg name="max_det" default="300"/>

--- a/auv_vision/auv_detection/launch/inc/tracker_front.launch
+++ b/auv_vision/auv_detection/launch/inc/tracker_front.launch
@@ -8,7 +8,7 @@
   <arg name="ultralytics_models_dir" default="$(find ultralytics_ros)/models"/>
   <arg name="input_topic" default="/$(arg namespace)/cameras/cam_front/image_corrected"/>
   <arg name="result_topic" default="/yolo_result_front"/>
-  <arg name="result_image_topic" default="/yolo_image_front"/>
+  <arg name="result_image_topic" default="/yolo_front/image_raw/compressed"/>
   <arg name="conf_thres" default="0.25"/>
   <arg name="iou_thres" default="0.45"/>
   <arg name="max_det" default="300"/>

--- a/auv_vision/auv_detection/launch/inc/tracker_mini.launch
+++ b/auv_vision/auv_detection/launch/inc/tracker_mini.launch
@@ -8,7 +8,7 @@
   <arg name="ultralytics_models_dir" default="$(find ultralytics_ros)/models"/>
   <arg name="input_topic" default="/$(arg namespace)/cameras/cam_front/image_corrected"/>
   <arg name="result_topic" default="/yolo_result_front"/>
-  <arg name="result_image_topic" default="/yolo_image_front"/>
+  <arg name="result_image_topic" default="/yolo_front/image_raw/compressed"/>
   <arg name="conf_thres" default="0.25"/>
   <arg name="iou_thres" default="0.45"/>
   <arg name="max_det" default="300"/>

--- a/auv_vision/auv_detection/launch/inc/tracker_realsense.launch
+++ b/auv_vision/auv_detection/launch/inc/tracker_realsense.launch
@@ -7,7 +7,7 @@
   <arg name="ultralytics_models_dir" default="$(find ultralytics_ros)/models"/>
   <arg name="input_topic" default="/$(arg namespace)/camera/color/image_raw"/>
   <arg name="result_topic" default="/yolo_result_realsense"/>
-  <arg name="result_image_topic" default="/yolo_image_realsense"/>
+  <arg name="result_image_topic" default="/yolo_realsense/image_raw/compressed"/>
   <arg name="conf_thres" default="0.25"/>
   <arg name="iou_thres" default="0.45"/>
   <arg name="max_det" default="300"/>

--- a/auv_vision/auv_detection/launch/inc/tracker_segment.launch
+++ b/auv_vision/auv_detection/launch/inc/tracker_segment.launch
@@ -8,7 +8,7 @@
   <arg name="ultralytics_models_dir" default="$(find ultralytics_ros)/models"/>
   <arg name="input_topic" default="/$(arg namespace)/cameras/cam_bottom/image_rect_color"/>
   <arg name="result_topic" default="/yolo_result_seg"/>
-  <arg name="result_image_topic" default="/yolo_image_seg"/>
+  <arg name="result_image_topic" default="/yolo_seg/image_raw/compressed"/>
   <arg name="conf_thres" default="0.25"/>
   <arg name="iou_thres" default="0.45"/>
   <arg name="max_det" default="300"/>

--- a/auv_vision/auv_detection/launch/inc/tracker_torpedo.launch
+++ b/auv_vision/auv_detection/launch/inc/tracker_torpedo.launch
@@ -8,7 +8,7 @@
   <arg name="ultralytics_models_dir" default="$(find ultralytics_ros)/models"/>
   <arg name="input_topic" default="/$(arg namespace)/cameras/cam_torpedo"/>
   <arg name="result_topic" default="/yolo_result_torpedo"/>
-  <arg name="result_image_topic" default="/yolo_image_torpedo"/>
+  <arg name="result_image_topic" default="/yolo_torpedo/image_raw/compressed"/>
   <arg name="conf_thres" default="0.25"/>
   <arg name="iou_thres" default="0.45"/>
   <arg name="max_det" default="300"/>


### PR DESCRIPTION
- [ ] need to make cam_bottom images smaller

Yolo image topics now follow this structure: `/yolo_*/image_raw/compressed`

What it excludes
- Any topic containing `image`
- Any topic containing `compressed`
- Any topic ending with 
  - `points_filtered` - `/taluy/detection_cloud`
  - `points` - for `/taluy/camera/depth/color/points`
  - `cloud` - for `/taluy/detection_cloud`
  - `mask` - `/taluy/bottle_mask` and `/taluy/pipe_mask`

Exceptions we still record
- `*/image_rect_color/compressed`
- `/yolo_*/image_raw/compressed`
- `*/camera/color/image_raw/compressed` for RealSense color
- `*/camera/depth/image_rect_raw/compressed` for RealSense depth